### PR TITLE
fix: remove margin left of arrow in section header

### DIFF
--- a/src/lib/components/SectionHeader.svelte
+++ b/src/lib/components/SectionHeader.svelte
@@ -5,7 +5,7 @@
 <div class="container pt-4">
 	<a
 		href={attrs.link ? attrs.link : '#'}
-		class="flex gap-2 items-center border-b border-gray-200 py-4"
+		class="flex gap-2 items-center border-b border-gray-200 py-4 hover:underline underline-offset-2"
 	>
 		{@html attrs.icon}
 		<h2 class="uppercase tracking-wide text-base font-semibold">{attrs.headline}</h2>
@@ -16,6 +16,7 @@
 				viewBox="0 0 16 14"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
+				class="w-3"
 			>
 				<path
 					d="M1 7H15"


### PR DESCRIPTION
Resolves #27

- Removed margin left to show arrow next to heading
- Slightly adapted code format for better readability (opinionated)