### PR TITLE
Test apollo graphql codegen

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -1,0 +1,34 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+	schema: 'https://base.klimadashboard.org/graphql',
+	documents: './src/**/*.gql',
+
+	// Single file config
+	// generates: {
+	// 	'./src/graphql/generated.ts': {
+	// 		plugins: ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo']
+	// 	}
+	// },
+
+	// Colocation config
+	generates: {
+		'src/types.ts': {
+			plugins: ['typescript']
+		},
+		'src/': {
+			preset: 'near-operation-file',
+			presetConfig: {
+				extension: '.generated.ts',
+				baseTypesPath: 'types.ts',
+				folder: '__generated__'
+			},
+			plugins: ['typescript-operations', 'graphql-codegen-svelte-apollo']
+		}
+	},
+	config: {
+		clientPath: '@/apolloClient',
+		asyncQuery: true
+	}
+};
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "klimadashboard-core",
 			"version": "2.0.0",
 			"dependencies": {
+				"@apollo/client": "^3.13.7",
 				"@directus/sdk": "^16.1.1",
 				"@splidejs/svelte-splide": "^0.2.9",
 				"@sveltejs/adapter-auto": "^4.0.0",
@@ -22,9 +23,14 @@
 				"mapbox-gl": "^2.15.0",
 				"papaparse": "^5.3.2",
 				"playwright": "^1.49.1",
-				"vite": "^5.0.0"
+				"vite": "^5.0.0",
+				"zod": "^3.24.2"
 			},
 			"devDependencies": {
+				"@graphql-codegen/cli": "^5.0.5",
+				"@graphql-codegen/near-operation-file-preset": "^3.0.0",
+				"@graphql-codegen/typescript": "^4.1.6",
+				"@graphql-codegen/typescript-operations": "^4.6.0",
 				"@playwright/test": "^1.21.0",
 				"@sveltejs/adapter-node": "^5.2.12",
 				"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
@@ -34,6 +40,8 @@
 				"@typescript-eslint/parser": "5.45.0",
 				"eslint": "^8.12.0",
 				"eslint-config-prettier": "^8.3.0",
+				"graphql": "^16.10.0",
+				"graphql-codegen-svelte-apollo": "^1.1.0",
 				"postcss": "^8.4.13",
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
@@ -41,7 +49,7 @@
 				"svelte-check": "^3.4.3",
 				"svelte-preprocess": "^5.0.4",
 				"tailwindcss": "^4.0.5",
-				"typescript": "^5.1.3"
+				"typescript": "^5.8.3"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -68,6 +76,868 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@apollo/client": {
+			"version": "3.13.7",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.7.tgz",
+			"integrity": "sha512-jOp8EctxOirgg5BSV0hgpcUSprrW7b9pf4r8ybUcY6Z+0T+ja5W82kI/rJeLUHxhT3YOKBm+72hWUHfsNIa+Fg==",
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"@wry/caches": "^1.0.0",
+				"@wry/equality": "^0.5.6",
+				"@wry/trie": "^0.5.0",
+				"graphql-tag": "^2.12.6",
+				"hoist-non-react-statics": "^3.3.2",
+				"optimism": "^0.18.0",
+				"prop-types": "^15.7.2",
+				"rehackt": "^0.1.0",
+				"symbol-observable": "^4.0.0",
+				"ts-invariant": "^0.10.3",
+				"tslib": "^2.3.0",
+				"zen-observable-ts": "^1.2.5"
+			},
+			"peerDependencies": {
+				"graphql": "^15.0.0 || ^16.0.0",
+				"graphql-ws": "^5.5.5 || ^6.0.3",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+			},
+			"peerDependenciesMeta": {
+				"graphql-ws": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"subscriptions-transport-ws": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@apollo/client/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
+		"node_modules/@ardatan/relay-compiler": {
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.3.tgz",
+			"integrity": "sha512-mBDFOGvAoVlWaWqs3hm1AciGHSQE1rqFc/liZTyYz/Oek9yZdT5H26pH2zAFuEiTiBVPPyMuqf5VjOFPI2DGsQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/generator": "^7.26.10",
+				"@babel/parser": "^7.26.10",
+				"@babel/runtime": "^7.26.10",
+				"chalk": "^4.0.0",
+				"fb-watchman": "^2.0.0",
+				"immutable": "~3.7.6",
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1",
+				"relay-runtime": "12.0.0",
+				"signedsource": "^1.0.0"
+			},
+			"bin": {
+				"relay-compiler": "bin/relay-compiler"
+			},
+			"peerDependencies": {
+				"graphql": "*"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+			"integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+			"integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.26.2",
+				"@babel/generator": "^7.26.10",
+				"@babel/helper-compilation-targets": "^7.26.5",
+				"@babel/helper-module-transforms": "^7.26.0",
+				"@babel/helpers": "^7.26.10",
+				"@babel/parser": "^7.26.10",
+				"@babel/template": "^7.26.9",
+				"@babel/traverse": "^7.26.10",
+				"@babel/types": "^7.26.10",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+			"integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-annotate-as-pure": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+			"integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+			"integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.26.8",
+				"@babel/helper-validator-option": "^7.25.9",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+			"integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-member-expression-to-functions": "^7.25.9",
+				"@babel/helper-optimise-call-expression": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.26.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+				"@babel/traverse": "^7.27.0",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+			"integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+			"integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+			"integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-optimise-call-expression": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+			"integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+			"integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-replace-supers": {
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+			"integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^7.25.9",
+				"@babel/helper-optimise-call-expression": "^7.25.9",
+				"@babel/traverse": "^7.26.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+			"integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+			"integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+			"integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.27.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-proposal-class-properties": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+			"integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^7.18.6",
+				"@babel/helper-plugin-utils": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.20.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+			"integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
+			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.20.5",
+				"@babel/helper-compilation-targets": "^7.20.7",
+				"@babel/helper-plugin-utils": "^7.20.2",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.20.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-flow": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
+			"integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-assertions": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+			"integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-jsx": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+			"integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-arrow-functions": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+			"integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+			"integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.26.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-block-scoping": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.0.tgz",
+			"integrity": "sha512-u1jGphZ8uDI2Pj/HJj6YQ6XQLZCNjOlprjxB5SVz6rq2T6SwAR+CdrWK0CP7F+9rDVMXdB0+r6Am5G5aobOjAQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.26.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-classes": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+			"integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-compilation-targets": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.25.9",
+				"@babel/traverse": "^7.25.9",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-classes/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/plugin-transform-computed-properties": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+			"integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/template": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-destructuring": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+			"integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-flow-strip-types": {
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz",
+			"integrity": "sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/plugin-syntax-flow": "^7.26.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-for-of": {
+			"version": "7.26.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+			"integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-function-name": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+			"integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-literals": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+			"integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-member-expression-literals": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+			"integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-modules-commonjs": {
+			"version": "7.26.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+			"integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-module-transforms": "^7.26.0",
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-object-super": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+			"integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-parameters": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+			"integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-property-literals": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+			"integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
+			"integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
+			"integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-module-imports": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/plugin-syntax-jsx": "^7.25.9",
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-shorthand-properties": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+			"integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-spread": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+			"integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-template-literals": {
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+			"integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.26.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+			"integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+			"integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+			"integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"@babel/generator": "^7.27.0",
+				"@babel/parser": "^7.27.0",
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@directus/sdk": {
 			"version": "16.1.2",
 			"resolved": "https://registry.npmjs.org/@directus/sdk/-/sdk-16.1.2.tgz",
@@ -78,6 +948,65 @@
 			"funding": {
 				"url": "https://github.com/directus/directus?sponsor=1"
 			}
+		},
+		"node_modules/@envelop/core": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@envelop/core/-/core-5.2.3.tgz",
+			"integrity": "sha512-KfoGlYD/XXQSc3BkM1/k15+JQbkQ4ateHazeZoWl9P71FsLTDXSjGy6j7QqfhpIDSbxNISqhPMfZHYSbDFOofQ==",
+			"dev": true,
+			"dependencies": {
+				"@envelop/instrumentation": "^1.0.0",
+				"@envelop/types": "^5.2.1",
+				"@whatwg-node/promise-helpers": "^1.2.4",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@envelop/core/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@envelop/instrumentation": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+			"integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/promise-helpers": "^1.2.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@envelop/instrumentation/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@envelop/types": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@envelop/types/-/types-5.2.1.tgz",
+			"integrity": "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/promise-helpers": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@envelop/types/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.21.5",
@@ -479,6 +1408,1321 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@graphql-codegen/add": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-5.0.3.tgz",
+			"integrity": "sha512-SxXPmramkth8XtBlAHu4H4jYcYXM/o3p01+psU+0NADQowA8jtYkK6MW5rV6T+CxkEaNZItfSmZRPgIuypcqnA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.0.3",
+				"tslib": "~2.6.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/add/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/cli": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.5.tgz",
+			"integrity": "sha512-9p9SI5dPhJdyU+O6p1LUqi5ajDwpm6pUhutb1fBONd0GZltLFwkgWFiFtM6smxkYXlYVzw61p1kTtwqsuXO16w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/generator": "^7.18.13",
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.18.13",
+				"@graphql-codegen/client-preset": "^4.6.0",
+				"@graphql-codegen/core": "^4.0.2",
+				"@graphql-codegen/plugin-helpers": "^5.0.3",
+				"@graphql-tools/apollo-engine-loader": "^8.0.0",
+				"@graphql-tools/code-file-loader": "^8.0.0",
+				"@graphql-tools/git-loader": "^8.0.0",
+				"@graphql-tools/github-loader": "^8.0.0",
+				"@graphql-tools/graphql-file-loader": "^8.0.0",
+				"@graphql-tools/json-file-loader": "^8.0.0",
+				"@graphql-tools/load": "^8.0.0",
+				"@graphql-tools/prisma-loader": "^8.0.0",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@whatwg-node/fetch": "^0.10.0",
+				"chalk": "^4.1.0",
+				"cosmiconfig": "^8.1.3",
+				"debounce": "^1.2.0",
+				"detect-indent": "^6.0.0",
+				"graphql-config": "^5.1.1",
+				"inquirer": "^8.0.0",
+				"is-glob": "^4.0.1",
+				"jiti": "^1.17.1",
+				"json-to-pretty-yaml": "^1.2.2",
+				"listr2": "^4.0.5",
+				"log-symbols": "^4.0.0",
+				"micromatch": "^4.0.5",
+				"shell-quote": "^1.7.3",
+				"string-env-interpolation": "^1.0.1",
+				"ts-log": "^2.2.3",
+				"tslib": "^2.4.0",
+				"yaml": "^2.3.1",
+				"yargs": "^17.0.0"
+			},
+			"bin": {
+				"gql-gen": "cjs/bin.js",
+				"graphql-code-generator": "cjs/bin.js",
+				"graphql-codegen": "cjs/bin.js",
+				"graphql-codegen-esm": "esm/bin.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"@parcel/watcher": "^2.1.0",
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@parcel/watcher": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@graphql-codegen/cli/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/cli/node_modules/yaml": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+			"dev": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@graphql-codegen/client-preset": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.8.0.tgz",
+			"integrity": "sha512-IVtTl7GsPMbQihk5+l5fDYksnPPOoC52sKxzquyIyuecZLEB7W3nNLV29r6+y+tjXTRPA774FR7CHGA2adzhjw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.20.2",
+				"@babel/template": "^7.20.7",
+				"@graphql-codegen/add": "^5.0.3",
+				"@graphql-codegen/gql-tag-operations": "4.0.17",
+				"@graphql-codegen/plugin-helpers": "^5.1.0",
+				"@graphql-codegen/typed-document-node": "^5.1.1",
+				"@graphql-codegen/typescript": "^4.1.6",
+				"@graphql-codegen/typescript-operations": "^4.6.0",
+				"@graphql-codegen/visitor-plugin-common": "^5.8.0",
+				"@graphql-tools/documents": "^1.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"@graphql-typed-document-node/core": "3.2.0",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+				"graphql-sock": "^1.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/client-preset/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/core": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.2.tgz",
+			"integrity": "sha512-IZbpkhwVqgizcjNiaVzNAzm/xbWT6YnGgeOLwVjm4KbJn3V2jchVtuzHH09G5/WkkLSk2wgbXNdwjM41JxO6Eg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.0.3",
+				"@graphql-tools/schema": "^10.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"tslib": "~2.6.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/core/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/gql-tag-operations": {
+			"version": "4.0.17",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-4.0.17.tgz",
+			"integrity": "sha512-2pnvPdIG6W9OuxkrEZ6hvZd142+O3B13lvhrZ48yyEBh2ujtmKokw0eTwDHtlXUqjVS0I3q7+HB2y12G/m69CA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.1.0",
+				"@graphql-codegen/visitor-plugin-common": "5.8.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"auto-bind": "~4.0.0",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/gql-tag-operations/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/near-operation-file-preset/-/near-operation-file-preset-3.0.0.tgz",
+			"integrity": "sha512-HRPaa7OsIAHQBFeGiTUVdjFcxzgvAs7uxSqcLEJgDpCr9cffpwnlgWP3gK79KnTiHsRkyb55U1K4YyrL00g1Cw==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/add": "^3.2.1",
+				"@graphql-codegen/plugin-helpers": "^3.0.0",
+				"@graphql-codegen/visitor-plugin-common": "2.13.1",
+				"@graphql-tools/utils": "^10.0.0",
+				"parse-filepath": "^1.0.2",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@ardatan/relay-compiler": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+			"integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.14.0",
+				"@babel/generator": "^7.14.0",
+				"@babel/parser": "^7.14.0",
+				"@babel/runtime": "^7.0.0",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.0.0",
+				"babel-preset-fbjs": "^3.4.0",
+				"chalk": "^4.0.0",
+				"fb-watchman": "^2.0.0",
+				"fbjs": "^3.0.0",
+				"glob": "^7.1.1",
+				"immutable": "~3.7.6",
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1",
+				"relay-runtime": "12.0.0",
+				"signedsource": "^1.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"relay-compiler": "bin/relay-compiler"
+			},
+			"peerDependencies": {
+				"graphql": "*"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/add": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-3.2.3.tgz",
+			"integrity": "sha512-sQOnWpMko4JLeykwyjFTxnhqjd/3NOG2OyMuvK76Wnnwh8DRrNf2VEs2kmSvLl7MndMlOj7Kh5U154dVcvhmKQ==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^3.1.1",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/add/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^9.0.0",
+				"change-case-all": "1.0.15",
+				"common-tags": "1.8.2",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/visitor-plugin-common": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
+			"integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^2.7.2",
+				"@graphql-tools/optimize": "^1.3.0",
+				"@graphql-tools/relay-operation-optimizer": "^6.5.0",
+				"@graphql-tools/utils": "^8.8.0",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.14",
+				"dependency-graph": "^0.11.0",
+				"graphql-tag": "^2.11.0",
+				"parse-filepath": "^1.0.2",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+			"integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^8.8.0",
+				"change-case-all": "1.0.14",
+				"common-tags": "1.8.2",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+			"version": "8.13.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+			"integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+			"integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+			"dev": true,
+			"dependencies": {
+				"change-case": "^4.1.2",
+				"is-lower-case": "^2.0.2",
+				"is-upper-case": "^2.0.2",
+				"lower-case": "^2.0.2",
+				"lower-case-first": "^2.0.2",
+				"sponge-case": "^1.0.1",
+				"swap-case": "^2.0.2",
+				"title-case": "^3.0.3",
+				"upper-case": "^2.0.2",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-tools/optimize": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+			"integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-tools/relay-operation-optimizer": {
+			"version": "6.5.18",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+			"integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+			"dev": true,
+			"dependencies": {
+				"@ardatan/relay-compiler": "12.0.0",
+				"@graphql-tools/utils": "^9.2.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@graphql-codegen/near-operation-file-preset/node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.0.tgz",
+			"integrity": "sha512-Y7cwEAkprbTKzVIe436TIw4w03jorsMruvCvu0HJkavaKMQbWY+lQ1RIuROgszDbxAyM35twB5/sUvYG5oW+yg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.0.0",
+				"change-case-all": "1.0.15",
+				"common-tags": "1.8.2",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/schema-ast": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.1.0.tgz",
+			"integrity": "sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.0.3",
+				"@graphql-tools/utils": "^10.0.0",
+				"tslib": "~2.6.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/typed-document-node": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.1.1.tgz",
+			"integrity": "sha512-Bp/BrMZDKRwzuVeLv+pSljneqONM7gqu57ZaV34Jbncu2hZWMRDMfizTKghoEwwZbRCYYfJO9tA0sYVVIfI1kg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.1.0",
+				"@graphql-codegen/visitor-plugin-common": "5.8.0",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.15",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/typed-document-node/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/typescript": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.1.6.tgz",
+			"integrity": "sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.1.0",
+				"@graphql-codegen/schema-ast": "^4.0.2",
+				"@graphql-codegen/visitor-plugin-common": "5.8.0",
+				"auto-bind": "~4.0.0",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/typescript-operations": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.6.0.tgz",
+			"integrity": "sha512-/EltSdE/uPoEAblRTVLABVDhsrE//Kl3pCflyG1PWl4gWL9/OzQXYGjo6TF6bPMVn/QBWoO0FeboWf+bk84SXA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.1.0",
+				"@graphql-codegen/typescript": "^4.1.6",
+				"@graphql-codegen/visitor-plugin-common": "5.8.0",
+				"auto-bind": "~4.0.0",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+				"graphql-sock": "^1.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-codegen/visitor-plugin-common": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.8.0.tgz",
+			"integrity": "sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^5.1.0",
+				"@graphql-tools/optimize": "^2.0.0",
+				"@graphql-tools/relay-operation-optimizer": "^7.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.15",
+				"dependency-graph": "^0.11.0",
+				"graphql-tag": "^2.11.0",
+				"parse-filepath": "^1.0.2",
+				"tslib": "~2.6.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+			"dev": true
+		},
+		"node_modules/@graphql-hive/signal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-hive/signal/-/signal-1.0.0.tgz",
+			"integrity": "sha512-RiwLMc89lTjvyLEivZ/qxAC5nBHoS2CtsWFSOsN35sxG9zoo5Z+JsFHM8MlvmO9yt+MJNIyC5MLE1rsbOphlag==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader": {
+			"version": "8.0.20",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.20.tgz",
+			"integrity": "sha512-m5k9nXSyjq31yNsEqDXLyykEjjn3K3Mo73oOKI+Xjy8cpnsgbT4myeUJIYYQdLrp7fr9Y9p7ZgwT5YcnwmnAbA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.6",
+				"@whatwg-node/fetch": "^0.10.0",
+				"sync-fetch": "0.6.0-2",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/apollo-engine-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/batch-execute": {
+			"version": "9.0.15",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.15.tgz",
+			"integrity": "sha512-qlWUl6yi87FU5WvyJ0uD81R4Y30oQIuW3mJCjOrEvifyT+f/rEqSZFOhYrofYoZAoTcwqOhy6WgH+b9+AtRYjA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.1",
+				"@whatwg-node/promise-helpers": "^1.3.0",
+				"dataloader": "^2.2.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/batch-execute/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/code-file-loader": {
+			"version": "8.1.20",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.20.tgz",
+			"integrity": "sha512-GzIbjjWJIc04KWnEr8VKuPe0FA2vDTlkaeub5p4lLimljnJ6C0QSkOyCUnFmsB9jetQcHm0Wfmn/akMnFUG+wA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/graphql-tag-pluck": "8.3.19",
+				"@graphql-tools/utils": "^10.8.6",
+				"globby": "^11.0.3",
+				"tslib": "^2.4.0",
+				"unixify": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/code-file-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/delegate": {
+			"version": "10.2.17",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.2.17.tgz",
+			"integrity": "sha512-z+LpZrTQCEXA4fbdJcSsvhaMqT4xi/O8B0mP30ENGyTbSfa20QamOQx9jgCiw2ii/ucwxfGMhygwlpZG36EU4w==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/batch-execute": "^9.0.15",
+				"@graphql-tools/executor": "^1.4.7",
+				"@graphql-tools/schema": "^10.0.11",
+				"@graphql-tools/utils": "^10.8.1",
+				"@repeaterjs/repeater": "^3.0.6",
+				"@whatwg-node/promise-helpers": "^1.3.0",
+				"dataloader": "^2.2.3",
+				"dset": "^3.1.2",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/delegate/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/documents": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/documents/-/documents-1.0.1.tgz",
+			"integrity": "sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA==",
+			"dev": true,
+			"dependencies": {
+				"lodash.sortby": "^4.7.0",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/documents/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/executor": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.4.7.tgz",
+			"integrity": "sha512-U0nK9jzJRP9/9Izf1+0Gggd6K6RNRsheFo1gC/VWzfnsr0qjcOSS9qTjY0OTC5iTPt4tQ+W5Zpw/uc7mebI6aA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.6",
+				"@graphql-typed-document-node/core": "^3.2.0",
+				"@repeaterjs/repeater": "^3.0.4",
+				"@whatwg-node/disposablestack": "^0.0.6",
+				"@whatwg-node/promise-helpers": "^1.0.0",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-common": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-common/-/executor-common-0.0.4.tgz",
+			"integrity": "sha512-SEH/OWR+sHbknqZyROCFHcRrbZeUAyjCsgpVWCRjqjqRbiJiXq6TxNIIOmpXgkrXWW/2Ev4Wms6YSGJXjdCs6Q==",
+			"dev": true,
+			"dependencies": {
+				"@envelop/core": "^5.2.3",
+				"@graphql-tools/utils": "^10.8.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-graphql-ws": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-2.0.5.tgz",
+			"integrity": "sha512-gI/D9VUzI1Jt1G28GYpvm5ckupgJ5O8mi5Y657UyuUozX34ErfVdZ81g6oVcKFQZ60LhCzk7jJeykK48gaLhDw==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/executor-common": "^0.0.4",
+				"@graphql-tools/utils": "^10.8.1",
+				"@whatwg-node/disposablestack": "^0.0.6",
+				"graphql-ws": "^6.0.3",
+				"isomorphic-ws": "^5.0.0",
+				"tslib": "^2.8.1",
+				"ws": "^8.17.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-graphql-ws/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/executor-http": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.3.3.tgz",
+			"integrity": "sha512-LIy+l08/Ivl8f8sMiHW2ebyck59JzyzO/yF9SFS4NH6MJZUezA1xThUXCDIKhHiD56h/gPojbkpcFvM2CbNE7A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-hive/signal": "^1.0.0",
+				"@graphql-tools/executor-common": "^0.0.4",
+				"@graphql-tools/utils": "^10.8.1",
+				"@repeaterjs/repeater": "^3.0.4",
+				"@whatwg-node/disposablestack": "^0.0.6",
+				"@whatwg-node/fetch": "^0.10.4",
+				"@whatwg-node/promise-helpers": "^1.3.0",
+				"meros": "^1.2.1",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-http/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/executor-legacy-ws": {
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.17.tgz",
+			"integrity": "sha512-TvltY6eL4DY1Vt66Z8kt9jVmNcI+WkvVPQZrPbMCM3rv2Jw/sWvSwzUBezRuWX0sIckMifYVh23VPcGBUKX/wg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.6",
+				"@types/ws": "^8.0.0",
+				"isomorphic-ws": "^5.0.0",
+				"tslib": "^2.4.0",
+				"ws": "^8.17.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/executor-legacy-ws/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/executor/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/git-loader": {
+			"version": "8.0.24",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.24.tgz",
+			"integrity": "sha512-ypLC9N2bKNC0QNbrEBTbWKwbV607f7vK2rSGi9uFeGr8E29tWplo6or9V/+TM0ZfIkUsNp/4QX/zKTgo8SbwQg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/graphql-tag-pluck": "8.3.19",
+				"@graphql-tools/utils": "^10.8.6",
+				"is-glob": "4.0.3",
+				"micromatch": "^4.0.8",
+				"tslib": "^2.4.0",
+				"unixify": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/git-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/github-loader": {
+			"version": "8.0.20",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.20.tgz",
+			"integrity": "sha512-Icch8bKZ1iP3zXCB9I0ded1hda9NPskSSalw7ZM21kXvLiOR5nZhdqPF65gCFkIKo+O4NR4Bp51MkKj+wl+vpg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/executor-http": "^1.1.9",
+				"@graphql-tools/graphql-tag-pluck": "^8.3.19",
+				"@graphql-tools/utils": "^10.8.6",
+				"@whatwg-node/fetch": "^0.10.0",
+				"@whatwg-node/promise-helpers": "^1.0.0",
+				"sync-fetch": "0.6.0-2",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/github-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/graphql-file-loader": {
+			"version": "8.0.19",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.19.tgz",
+			"integrity": "sha512-kyEZL4rRJ5LelfCXL3GLgbMiu5Zd7memZaL8ZxPXGI7DA8On1e5IVBH3zZJwf7LzhjSVnPaHM7O/bRzGvTbXzQ==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/import": "7.0.18",
+				"@graphql-tools/utils": "^10.8.6",
+				"globby": "^11.0.3",
+				"tslib": "^2.4.0",
+				"unixify": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/graphql-file-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/graphql-tag-pluck": {
+			"version": "8.3.19",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.19.tgz",
+			"integrity": "sha512-LEw/6IYOUz48HjbWntZXDCzSXsOIM1AyWZrlLoJOrA8QAlhFd8h5Tny7opCypj8FO9VvpPFugWoNDh5InPOEQA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.26.10",
+				"@babel/parser": "^7.26.10",
+				"@babel/plugin-syntax-import-assertions": "^7.26.0",
+				"@babel/traverse": "^7.26.10",
+				"@babel/types": "^7.26.10",
+				"@graphql-tools/utils": "^10.8.6",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/graphql-tag-pluck/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/import": {
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.18.tgz",
+			"integrity": "sha512-1tw1/1QLB0n5bPWfIrhCRnrHIlbMvbwuifDc98g4FPhJ7OXD+iUQe+IpmD5KHVwYWXWhZOuJuq45DfV/WLNq3A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.6",
+				"resolve-from": "5.0.0",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/import/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@graphql-tools/import/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/json-file-loader": {
+			"version": "8.0.18",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.18.tgz",
+			"integrity": "sha512-JjjIxxewgk8HeMR3npR3YbOkB7fxmdgmqB9kZLWdkRKBxrRXVzhryyq+mhmI0Evzt6pNoHIc3vqwmSctG2sddg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.6",
+				"globby": "^11.0.3",
+				"tslib": "^2.4.0",
+				"unixify": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/json-file-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/load": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.0.tgz",
+			"integrity": "sha512-OGfOm09VyXdNGJS/rLqZ6ztCiG2g6AMxhwtET8GZXTbnjptFc17GtKwJ3Jv5w7mjJ8dn0BHydvIuEKEUK4ciYw==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/schema": "^10.0.23",
+				"@graphql-tools/utils": "^10.8.6",
+				"p-limit": "3.1.0",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/load/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/merge": {
+			"version": "9.0.24",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
+			"integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^10.8.6",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/merge/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/optimize": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
+			"integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/optimize/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/prisma-loader": {
+			"version": "8.0.17",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.17.tgz",
+			"integrity": "sha512-fnuTLeQhqRbA156pAyzJYN0KxCjKYRU5bz1q/SKOwElSnAU4k7/G1kyVsWLh7fneY78LoMNH5n+KlFV8iQlnyg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/url-loader": "^8.0.15",
+				"@graphql-tools/utils": "^10.5.6",
+				"@types/js-yaml": "^4.0.0",
+				"@whatwg-node/fetch": "^0.10.0",
+				"chalk": "^4.1.0",
+				"debug": "^4.3.1",
+				"dotenv": "^16.0.0",
+				"graphql-request": "^6.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"jose": "^5.0.0",
+				"js-yaml": "^4.0.0",
+				"lodash": "^4.17.20",
+				"scuid": "^1.1.0",
+				"tslib": "^2.4.0",
+				"yaml-ast-parser": "^0.0.43"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/prisma-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/relay-operation-optimizer": {
+			"version": "7.0.19",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.19.tgz",
+			"integrity": "sha512-xnjLpfzw63yIX1bo+BVh4j1attSwqEkUbpJ+HAhdiSUa3FOQFfpWgijRju+3i87CwhjBANqdTZbcsqLT1hEXig==",
+			"dev": true,
+			"dependencies": {
+				"@ardatan/relay-compiler": "^12.0.3",
+				"@graphql-tools/utils": "^10.8.6",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/relay-operation-optimizer/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/schema": {
+			"version": "10.0.23",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
+			"integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/merge": "^9.0.24",
+				"@graphql-tools/utils": "^10.8.6",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/schema/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/url-loader": {
+			"version": "8.0.31",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.31.tgz",
+			"integrity": "sha512-QGP3py6DAdKERHO5D38Oi+6j+v0O3rkBbnLpyOo87rmIRbwE6sOkL5JeHegHs7EEJ279fBX6lMt8ry0wBMGtyA==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/executor-graphql-ws": "^2.0.1",
+				"@graphql-tools/executor-http": "^1.1.9",
+				"@graphql-tools/executor-legacy-ws": "^1.1.17",
+				"@graphql-tools/utils": "^10.8.6",
+				"@graphql-tools/wrap": "^10.0.16",
+				"@types/ws": "^8.0.0",
+				"@whatwg-node/fetch": "^0.10.0",
+				"@whatwg-node/promise-helpers": "^1.0.0",
+				"isomorphic-ws": "^5.0.0",
+				"sync-fetch": "0.6.0-2",
+				"tslib": "^2.4.0",
+				"ws": "^8.17.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/url-loader/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/utils": {
+			"version": "10.8.6",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
+			"integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"@whatwg-node/promise-helpers": "^1.0.0",
+				"cross-inspect": "1.0.1",
+				"dset": "^3.1.4",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/utils/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-tools/wrap": {
+			"version": "10.0.35",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.35.tgz",
+			"integrity": "sha512-qBga3wo7+GqY+ClGexiyRz9xgy1RWozZryTuGX8usGWPa4wKi/tJS4rKWQQesgB3Fh//SZUCRA5u2nwZaZQw1Q==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/delegate": "^10.2.17",
+				"@graphql-tools/schema": "^10.0.11",
+				"@graphql-tools/utils": "^10.8.1",
+				"@whatwg-node/promise-helpers": "^1.3.0",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/@graphql-tools/wrap/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@graphql-typed-document-node/core": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+			"integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.13.0",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -661,6 +2905,12 @@
 			"version": "1.0.0-next.28",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
 			"integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw=="
+		},
+		"node_modules/@repeaterjs/repeater": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+			"integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+			"dev": true
 		},
 		"node_modules/@rollup/plugin-commonjs": {
 			"version": "28.0.2",
@@ -1339,6 +3589,12 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
 		},
+		"node_modules/@types/js-yaml": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+			"dev": true
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1371,6 +3627,15 @@
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
 			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
 			"dev": true
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.45.0",
@@ -1564,6 +3829,141 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
 		},
+		"node_modules/@whatwg-node/disposablestack": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+			"integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/promise-helpers": "^1.0.0",
+				"tslib": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@whatwg-node/disposablestack/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@whatwg-node/fetch": {
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.5.tgz",
+			"integrity": "sha512-+yFJU3hmXPAHJULwx0VzCIsvr/H0lvbPvbOH3areOH3NAuCxCwaJsQ8w6/MwwMcvEWIynSsmAxoyaH04KeosPg==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/node-fetch": "^0.7.11",
+				"urlpattern-polyfill": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@whatwg-node/node-fetch": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.17.tgz",
+			"integrity": "sha512-Ni8A2H/r6brNf4u8Y7ATxmWUD0xltsQ6a4NnjWSbw4PgaT34CbY+u4QtVsFj9pTC3dBKJADKjac3AieAig+PZA==",
+			"dev": true,
+			"dependencies": {
+				"@whatwg-node/disposablestack": "^0.0.6",
+				"@whatwg-node/promise-helpers": "^1.2.5",
+				"busboy": "^1.6.0",
+				"tslib": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@whatwg-node/node-fetch/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@whatwg-node/promise-helpers": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.0.tgz",
+			"integrity": "sha512-486CouizxHXucj8Ky153DDragfkMcHtVEToF5Pn/fInhUUSiCmt9Q4JVBa6UK5q4RammFBtGQ4C9qhGlXU9YbA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@whatwg-node/promise-helpers/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/@wry/caches": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+			"integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@wry/caches/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
+		"node_modules/@wry/context": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+			"integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@wry/context/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
+		"node_modules/@wry/equality": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+			"integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@wry/equality/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
+		"node_modules/@wry/trie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+			"integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@wry/trie/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1591,6 +3991,28 @@
 				"acorn": ">=8.9.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1604,6 +4026,33 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -1675,6 +4124,33 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"dev": true
+		},
+		"node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/auto-bind": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+			"integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1683,10 +4159,74 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/babel-plugin-syntax-trailing-function-commas": {
+			"version": "7.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+			"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+			"dev": true
+		},
+		"node_modules/babel-preset-fbjs": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+			"integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+			"dev": true,
+			"dependencies": {
+				"@babel/plugin-proposal-class-properties": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-syntax-class-properties": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.0.0",
+				"@babel/plugin-transform-classes": "^7.0.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.0.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.0.0",
+				"@babel/plugin-transform-property-literals": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
@@ -1698,6 +4238,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -1721,6 +4272,71 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001688",
+				"electron-to-chromium": "^1.5.73",
+				"node-releases": "^2.0.19",
+				"update-browserslist-db": "^1.1.1"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"dependencies": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/buffer-crc32": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -1730,6 +4346,18 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dev": true,
+			"dependencies": {
+				"streamsearch": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1737,6 +4365,68 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"dev": true,
+			"dependencies": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/camel-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001713",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+			"integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			]
+		},
+		"node_modules/capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/capital-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -1752,6 +4442,56 @@
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
+		},
+		"node_modules/change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"dev": true,
+			"dependencies": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/change-case-all": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+			"integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+			"dev": true,
+			"dependencies": {
+				"change-case": "^4.1.2",
+				"is-lower-case": "^2.0.2",
+				"is-upper-case": "^2.0.2",
+				"lower-case": "^2.0.2",
+				"lower-case-first": "^2.0.2",
+				"sponge-case": "^1.0.1",
+				"swap-case": "^2.0.2",
+				"title-case": "^3.0.3",
+				"upper-case": "^2.0.2",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/change-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
 		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
@@ -1789,6 +4529,104 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"dependencies": {
+				"restore-cursor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+			"dev": true,
+			"dependencies": {
+				"slice-ansi": "^3.0.0",
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1813,12 +4651,27 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"node_modules/colorette": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"dev": true
+		},
 		"node_modules/commander": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
 			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/common-tags": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/commondir": {
@@ -1832,6 +4685,29 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
+		"node_modules/constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			}
+		},
+		"node_modules/constant-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -1839,6 +4715,59 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/cosmiconfig": {
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/cross-fetch": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+			"integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+			"dev": true,
+			"dependencies": {
+				"node-fetch": "^2.7.0"
+			}
+		},
+		"node_modules/cross-inspect": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+			"integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/cross-inspect/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -2239,10 +5168,31 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/dataloader": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+			"integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
+			"dev": true
+		},
 		"node_modules/dayjs": {
 			"version": "1.11.13",
 			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
 			"integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+		},
+		"node_modules/debounce": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+			"integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+			"dev": true
 		},
 		"node_modules/debug": {
 			"version": "4.4.0",
@@ -2260,6 +5210,15 @@
 				}
 			}
 		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2273,12 +5232,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/defaults": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+			"dev": true,
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/delaunator": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
 			"integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
 			"dependencies": {
 				"robust-predicates": "^3.0.2"
+			}
+		},
+		"node_modules/dependency-graph": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+			"integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/detect-indent": {
@@ -2334,10 +5314,59 @@
 			"resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
 			"integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA=="
 		},
+		"node_modules/dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/dot-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/dotenv": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+			"integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dset": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+			"integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/earcut": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
 			"integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.136",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
+			"integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
+			"dev": true
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.1",
@@ -2349,6 +5378,15 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es6-promise": {
@@ -2392,6 +5430,15 @@
 				"@esbuild/win32-arm64": "0.21.5",
 				"@esbuild/win32-ia32": "0.21.5",
 				"@esbuild/win32-x64": "0.21.5"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2683,6 +5730,32 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/external-editor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
+			"dependencies": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/external-editor/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2739,6 +5812,36 @@
 			"resolved": "https://registry.npmjs.org/fathom-client/-/fathom-client-3.7.2.tgz",
 			"integrity": "sha512-sWtaNivhg7uwp/q1bUuIiNj4LeQZMEZ5NXXFFpZ8le4uDedAfQG84gPOdYehtVXbl+1yX2s8lmXZ2+IQ9a/xxA=="
 		},
+		"node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dev": true,
+			"dependencies": {
+				"bser": "2.1.1"
+			}
+		},
+		"node_modules/fbjs": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+			"integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+			"dev": true,
+			"dependencies": {
+				"cross-fetch": "^3.1.5",
+				"fbjs-css-vars": "^1.0.0",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^1.0.35"
+			}
+		},
+		"node_modules/fbjs-css-vars": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+			"dev": true
+		},
 		"node_modules/fdir": {
 			"version": "6.4.3",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
@@ -2751,6 +5854,53 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/figures": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/figures/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -2809,6 +5959,18 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
 			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
 		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2836,10 +5998,28 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/geojson-vt": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
 			"integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
 		},
 		"node_modules/get-stream": {
 			"version": "6.0.1",
@@ -2856,6 +6036,26 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
 			"integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
@@ -2912,6 +6112,450 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
+		"node_modules/graphql": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+			"integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+			"engines": {
+				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/graphql-codegen-svelte-apollo/-/graphql-codegen-svelte-apollo-1.1.0.tgz",
+			"integrity": "sha512-x7AxfzZV00rOlqllEQmpWpwVo0nJXQzoyK4yRRlGG8+OkEWLhbc3PnDgGU7YpBVrSrfL0Aoz3ienSDBQM3iT4Q==",
+			"dev": true,
+			"dependencies": {
+				"@apollo/client": "^3.2.7",
+				"@graphql-codegen/plugin-helpers": "^2.3.1",
+				"@graphql-codegen/visitor-plugin-common": "^2.5.1",
+				"camel-case": "^4.1.1",
+				"pascal-case": "^3.1.1"
+			},
+			"peerDependencies": {
+				"graphql": "^16.0.1"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@ardatan/relay-compiler": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+			"integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.14.0",
+				"@babel/generator": "^7.14.0",
+				"@babel/parser": "^7.14.0",
+				"@babel/runtime": "^7.0.0",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.0.0",
+				"babel-preset-fbjs": "^3.4.0",
+				"chalk": "^4.0.0",
+				"fb-watchman": "^2.0.0",
+				"fbjs": "^3.0.0",
+				"glob": "^7.1.1",
+				"immutable": "~3.7.6",
+				"invariant": "^2.2.4",
+				"nullthrows": "^1.1.1",
+				"relay-runtime": "12.0.0",
+				"signedsource": "^1.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"relay-compiler": "bin/relay-compiler"
+			},
+			"peerDependencies": {
+				"graphql": "*"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+			"integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^8.8.0",
+				"change-case-all": "1.0.14",
+				"common-tags": "1.8.2",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-codegen/plugin-helpers/node_modules/change-case-all": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+			"integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+			"dev": true,
+			"dependencies": {
+				"change-case": "^4.1.2",
+				"is-lower-case": "^2.0.2",
+				"is-upper-case": "^2.0.2",
+				"lower-case": "^2.0.2",
+				"lower-case-first": "^2.0.2",
+				"sponge-case": "^1.0.1",
+				"swap-case": "^2.0.2",
+				"title-case": "^3.0.3",
+				"upper-case": "^2.0.2",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-codegen/visitor-plugin-common": {
+			"version": "2.13.8",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz",
+			"integrity": "sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-codegen/plugin-helpers": "^3.1.2",
+				"@graphql-tools/optimize": "^1.3.0",
+				"@graphql-tools/relay-operation-optimizer": "^6.5.0",
+				"@graphql-tools/utils": "^9.0.0",
+				"auto-bind": "~4.0.0",
+				"change-case-all": "1.0.15",
+				"dependency-graph": "^0.11.0",
+				"graphql-tag": "^2.11.0",
+				"parse-filepath": "^1.0.2",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+			"integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/utils": "^9.0.0",
+				"change-case-all": "1.0.15",
+				"common-tags": "1.8.2",
+				"import-from": "4.0.0",
+				"lodash": "~4.17.0",
+				"tslib": "~2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-tools/optimize": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+			"integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-tools/relay-operation-optimizer": {
+			"version": "6.5.18",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+			"integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+			"dev": true,
+			"dependencies": {
+				"@ardatan/relay-compiler": "12.0.0",
+				"@graphql-tools/utils": "^9.2.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+			"integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/@graphql-tools/utils": {
+			"version": "8.13.1",
+			"resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+			"integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"dev": true
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"dev": true
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/graphql-codegen-svelte-apollo/node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/graphql-config": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.3.tgz",
+			"integrity": "sha512-RBhejsPjrNSuwtckRlilWzLVt2j8itl74W9Gke1KejDTz7oaA5kVd6wRn9zK9TS5mcmIYGxf7zN7a1ORMdxp1Q==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-tools/graphql-file-loader": "^8.0.0",
+				"@graphql-tools/json-file-loader": "^8.0.0",
+				"@graphql-tools/load": "^8.0.0",
+				"@graphql-tools/merge": "^9.0.0",
+				"@graphql-tools/url-loader": "^8.0.0",
+				"@graphql-tools/utils": "^10.0.0",
+				"cosmiconfig": "^8.1.0",
+				"jiti": "^2.0.0",
+				"minimatch": "^9.0.5",
+				"string-env-interpolation": "^1.0.1",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"peerDependencies": {
+				"cosmiconfig-toml-loader": "^1.0.0",
+				"graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			},
+			"peerDependenciesMeta": {
+				"cosmiconfig-toml-loader": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/graphql-config/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/graphql-config/node_modules/jiti": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+			"integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+			"dev": true,
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/graphql-config/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/graphql-config/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/graphql-request": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+			"integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+			"dev": true,
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.2.0",
+				"cross-fetch": "^3.1.5"
+			},
+			"peerDependencies": {
+				"graphql": "14 - 16"
+			}
+		},
+		"node_modules/graphql-sock": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graphql-sock/-/graphql-sock-1.0.1.tgz",
+			"integrity": "sha512-gSA0CXdNMvNlpEnH2GY1//SUY7laDsAn51sDm4yh6TTH5UkfbNINydyUAoMHHkAaCaOLNXELQmu3GVcSOw4twg==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"semantic-to-nullable": "dist/cli/to-nullable.js",
+				"semantic-to-strict": "dist/cli/to-strict.js"
+			},
+			"peerDependencies": {
+				"graphql": "15.x || 16.x || 17.x"
+			}
+		},
+		"node_modules/graphql-tag": {
+			"version": "2.12.6",
+			"resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+			"integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/graphql-tag/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
+		"node_modules/graphql-ws": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.4.tgz",
+			"integrity": "sha512-8b4OZtNOvv8+NZva8HXamrc0y1jluYC0+13gdh7198FKjVzXyTvVc95DCwGzaKEfn3YuWZxUqjJlHe3qKM/F2g==",
+			"devOptional": true,
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@fastify/websocket": "^10 || ^11",
+				"graphql": "^15.10.1 || ^16",
+				"uWebSockets.js": "^20",
+				"ws": "^8"
+			},
+			"peerDependenciesMeta": {
+				"@fastify/websocket": {
+					"optional": true
+				},
+				"uWebSockets.js": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/grid-index": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -2935,6 +6579,56 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"dev": true,
+			"dependencies": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/header-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -2975,6 +6669,15 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/immutable": {
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+			"integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2985,6 +6688,18 @@
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+			"integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3007,6 +6722,15 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3022,6 +6746,32 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"node_modules/inquirer": {
+			"version": "8.2.6",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+			"integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.1.1",
+				"cli-cursor": "^3.1.0",
+				"cli-width": "^3.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.21",
+				"mute-stream": "0.0.8",
+				"ora": "^5.4.1",
+				"run-async": "^2.4.0",
+				"rxjs": "^7.5.5",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"through": "^2.3.6",
+				"wrap-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/internmap": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -3029,6 +6779,34 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"node_modules/is-absolute": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+			"dev": true,
+			"dependencies": {
+				"is-relative": "^1.0.0",
+				"is-windows": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -3065,6 +6843,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3075,6 +6862,30 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+			"integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/is-lower-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/is-module": {
 			"version": "1.0.0",
@@ -3108,10 +6919,102 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/is-relative": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+			"dev": true,
+			"dependencies": {
+				"is-unc-path": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-unc-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+			"dev": true,
+			"dependencies": {
+				"unc-path-regex": "^0.1.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+			"integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/is-upper-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+		},
+		"node_modules/isomorphic-ws": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+			"integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+			"dev": true,
+			"peerDependencies": {
+				"ws": "*"
+			}
+		},
+		"node_modules/jiti": {
+			"version": "1.21.7",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+			"dev": true,
+			"bin": {
+				"jiti": "bin/jiti.js"
+			}
+		},
+		"node_modules/jose": {
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+			"integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -3124,10 +7027,28 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -3138,6 +7059,31 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+		},
+		"node_modules/json-to-pretty-yaml": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+			"integrity": "sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A==",
+			"dev": true,
+			"dependencies": {
+				"remedial": "^1.0.7",
+				"remove-trailing-spaces": "^1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.2.0"
+			}
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/kdbush": {
 			"version": "4.0.2",
@@ -3402,6 +7348,56 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true
+		},
+		"node_modules/listr2": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+			"integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+			"dev": true,
+			"dependencies": {
+				"cli-truncate": "^2.1.0",
+				"colorette": "^2.0.16",
+				"log-update": "^4.0.0",
+				"p-map": "^4.0.0",
+				"rfdc": "^1.3.0",
+				"rxjs": "^7.5.5",
+				"through": "^2.3.8",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"enquirer": ">= 2.3.0 < 3"
+			},
+			"peerDependenciesMeta": {
+				"enquirer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/listr2/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -3421,10 +7417,123 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
+		"node_modules/lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+			"dev": true
+		},
+		"node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+			"integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-escapes": "^4.3.0",
+				"cli-cursor": "^3.1.0",
+				"slice-ansi": "^4.0.0",
+				"wrap-ansi": "^6.2.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/lower-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+			"integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/lower-case-first/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/lower-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",
@@ -3432,6 +7541,15 @@
 			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
+			}
+		},
+		"node_modules/map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/mapbox-gl": {
@@ -3472,6 +7590,23 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/meros": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
+			"integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=13"
+			},
+			"peerDependencies": {
+				"@types/node": ">=13"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3495,6 +7630,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/min-indent": {
@@ -3563,6 +7707,12 @@
 			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
 			"integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
 		},
+		"node_modules/mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.8",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -3591,11 +7741,92 @@
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
 		},
+		"node_modules/no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"dev": true,
+			"dependencies": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/no-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"dev": true
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nullthrows": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+			"dev": true
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3607,6 +7838,37 @@
 			"dependencies": {
 				"wrappy": "1"
 			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/optimism": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+			"integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+			"dependencies": {
+				"@wry/caches": "^1.0.0",
+				"@wry/context": "^0.7.0",
+				"@wry/trie": "^0.5.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/optimism/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -3622,6 +7884,38 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/ora": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^4.1.0",
+				"chalk": "^4.1.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.5.0",
+				"is-interactive": "^1.0.0",
+				"is-unicode-supported": "^0.1.0",
+				"log-symbols": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/p-limit": {
@@ -3652,10 +7946,50 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"dev": true,
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/papaparse": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.1.tgz",
 			"integrity": "sha512-EuEKUhyxrHVozD7g3/ztsJn6qaKse8RPfR6buNB2dMJvdtXNhcw8jccVi/LxNEY3HVrV6GO6Z4OoeCG9Iy9wpA=="
+		},
+		"node_modules/param-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+			"dev": true,
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/param-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
@@ -3667,6 +8001,70 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/parse-filepath": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+			"integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
+			"dev": true,
+			"dependencies": {
+				"is-absolute": "^1.0.0",
+				"map-cache": "^0.2.0",
+				"path-root": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/pascal-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"dev": true,
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/path-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -3697,6 +8095,27 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
+		},
+		"node_modules/path-root": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+			"integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+			"dev": true,
+			"dependencies": {
+				"path-root-regex": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-root-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+			"integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -3909,6 +8328,25 @@
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
 			}
 		},
+		"node_modules/promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
+			"dependencies": {
+				"asap": "~2.0.3"
+			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
 		"node_modules/protocol-buffers-schema": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
@@ -3946,6 +8384,25 @@
 			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
 			"integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
 		},
+		"node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3970,6 +8427,12 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
+		},
 		"node_modules/regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -3981,6 +8444,70 @@
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
 			}
+		},
+		"node_modules/rehackt": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+			"integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "*"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/relay-runtime": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+			"integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.0.0",
+				"fbjs": "^3.0.0",
+				"invariant": "^2.2.4"
+			}
+		},
+		"node_modules/remedial": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+			"integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+			"dev": true
+		},
+		"node_modules/remove-trailing-spaces": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.9.tgz",
+			"integrity": "sha512-xzG7w5IRijvIkHIjDk65URsJJ7k4J95wmcArY5PRcmjldIOl7oTvG8+X2Ag690R7SfwiOcHrWZKVc1Pp5WIOzA==",
+			"dev": true
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
@@ -4018,6 +8545,19 @@
 				"protocol-buffers-schema": "^3.3.1"
 			}
 		},
+		"node_modules/restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -4026,6 +8566,12 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/rfdc": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"dev": true
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
@@ -4037,26 +8583,6 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -4104,6 +8630,15 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/run-async": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4131,6 +8666,21 @@
 			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
 			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
 		},
+		"node_modules/rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/rxjs/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -4141,6 +8691,26 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -4159,27 +8729,6 @@
 				"rimraf": "^2.5.2"
 			}
 		},
-		"node_modules/sander/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/sander/node_modules/rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -4193,6 +8742,12 @@
 				"rimraf": "bin.js"
 			}
 		},
+		"node_modules/scuid": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+			"integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+			"dev": true
+		},
 		"node_modules/semver": {
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -4204,10 +8759,39 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
+		"node_modules/sentence-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true
+		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+			"dev": true
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -4227,6 +8811,30 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/shell-quote": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+			"integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/signedsource": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+			"integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==",
+			"dev": true
 		},
 		"node_modules/sirv": {
 			"version": "3.0.0",
@@ -4250,6 +8858,36 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/slice-ansi": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+			"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"dev": true,
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/snake-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
 		"node_modules/sorcery": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.1.tgz",
@@ -4271,6 +8909,59 @@
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sponge-case": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+			"integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/sponge-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-env-interpolation": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+			"integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+			"dev": true
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/strip-ansi": {
@@ -4501,6 +9192,61 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/swap-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+			"integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/swap-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/symbol-observable": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+			"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/sync-fetch": {
+			"version": "0.6.0-2",
+			"resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.6.0-2.tgz",
+			"integrity": "sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==",
+			"dev": true,
+			"dependencies": {
+				"node-fetch": "^3.3.2",
+				"timeout-signal": "^2.0.0",
+				"whatwg-mimetype": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/sync-fetch/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
 		"node_modules/tailwindcss": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.5.tgz",
@@ -4519,10 +9265,52 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
 		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+			"dev": true
+		},
+		"node_modules/timeout-signal": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-2.0.0.tgz",
+			"integrity": "sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/tinyqueue": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
 			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+		},
+		"node_modules/title-case": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+			"integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/title-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -4543,6 +9331,34 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
+		},
+		"node_modules/ts-invariant": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+			"integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ts-invariant/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
+		"node_modules/ts-log": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
+			"integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
+			"dev": true
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
@@ -4588,9 +9404,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -4600,11 +9416,130 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/ua-parser-js": {
+			"version": "1.0.40",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+			"integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/ua-parser-js"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/faisalman"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/faisalman"
+				}
+			],
+			"bin": {
+				"ua-parser-js": "script/cli.js"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/unc-path-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "6.19.8",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"devOptional": true
+		},
+		"node_modules/unixify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+			"integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+			"dev": true,
+			"dependencies": {
+				"normalize-path": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/unixify/node_modules/normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+			"dev": true,
+			"dependencies": {
+				"remove-trailing-separator": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/upper-case-first/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
+		},
+		"node_modules/upper-case/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -4613,6 +9548,12 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+			"integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+			"dev": true
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
@@ -4713,6 +9654,49 @@
 				"pbf": "^3.2.1"
 			}
 		},
+		"node_modules/wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"dev": true,
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4727,6 +9711,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"dev": true
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4735,10 +9725,60 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"node_modules/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+			"devOptional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
 		},
 		"node_modules/yaml": {
 			"version": "1.10.2",
@@ -4746,6 +9786,39 @@
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/yaml-ast-parser": {
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+			"integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+			"dev": true
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -4759,10 +9832,31 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/zen-observable": {
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+		},
+		"node_modules/zen-observable-ts": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+			"integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+			"dependencies": {
+				"zen-observable": "0.8.15"
+			}
+		},
 		"node_modules/zimmerframe": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
 			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="
+		},
+		"node_modules/zod": {
+			"version": "3.24.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"format": "prettier --plugin-search-dir . --write .",
+		"gql-codegen": "graphql-codegen"
 	},
 	"devDependencies": {
+		"@graphql-codegen/cli": "^5.0.5",
+		"@graphql-codegen/near-operation-file-preset": "^3.0.0",
+		"@graphql-codegen/typescript": "^4.1.6",
+		"@graphql-codegen/typescript-operations": "^4.6.0",
 		"@playwright/test": "^1.21.0",
 		"@sveltejs/adapter-node": "^5.2.12",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
@@ -18,6 +23,8 @@
 		"@typescript-eslint/parser": "5.45.0",
 		"eslint": "^8.12.0",
 		"eslint-config-prettier": "^8.3.0",
+		"graphql": "^16.10.0",
+		"graphql-codegen-svelte-apollo": "^1.1.0",
 		"postcss": "^8.4.13",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
@@ -25,10 +32,11 @@
 		"svelte-check": "^3.4.3",
 		"svelte-preprocess": "^5.0.4",
 		"tailwindcss": "^4.0.5",
-		"typescript": "^5.1.3"
+		"typescript": "^5.8.3"
 	},
 	"type": "module",
 	"dependencies": {
+		"@apollo/client": "^3.13.7",
 		"@directus/sdk": "^16.1.1",
 		"@splidejs/svelte-splide": "^0.2.9",
 		"@sveltejs/adapter-auto": "^4.0.0",
@@ -43,6 +51,7 @@
 		"mapbox-gl": "^2.15.0",
 		"papaparse": "^5.3.2",
 		"playwright": "^1.49.1",
-		"vite": "^5.0.0"
+		"vite": "^5.0.0",
+		"zod": "^3.24.2"
 	}
 }

--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -1,0 +1,8 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+
+const client = new ApolloClient({
+	uri: 'https://base.klimadashboard.org/graphql',
+	cache: new InMemoryCache()
+});
+
+export default client;

--- a/src/lib/components/charts/chartLine.svelte
+++ b/src/lib/components/charts/chartLine.svelte
@@ -1,4 +1,5 @@
 <script>
+	// @ts-nocheck
 	import { max, min, extent, bisector } from 'd3-array';
 	import { scaleLinear, scaleTime } from 'd3-scale';
 	import formatNumber from '$lib/stores/formatNumber';
@@ -24,8 +25,8 @@
 	export let minValue = 0;
 	export let preselectedIndex = 0;
 	export let showPulse = false;
-	export let invalidX;
-	export let invalidText;
+	export let invalidX = 0;
+	export let invalidText = '';
 	export let additionalYAxisUnit = '';
 
 	let chartHeight;

--- a/src/lib/components/charts/custom/mobilityRenewableShare/__generated__/mobilityRenewableShare.generated.ts
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/__generated__/mobilityRenewableShare.generated.ts
@@ -1,0 +1,125 @@
+import * as Types from '../../../../../../types';
+
+import client from "@/apolloClient";
+import type {
+        ApolloQueryResult, ObservableQuery, WatchQueryOptions, QueryOptions
+      } from "@apollo/client";
+import { readable } from "svelte/store";
+import type { Readable } from "svelte/store";
+import gql from "graphql-tag"
+export type GetMobilityRenewableShareQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type GetMobilityRenewableShareQuery = { __typename?: 'Query', mobility: Array<{ __typename?: 'mobility', period?: string | null, region?: string | null, value?: number | null }> };
+
+export type GetCountriesQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type GetCountriesQuery = { __typename?: 'Query', countries: Array<{ __typename?: 'countries', id: string, name_de?: string | null }> };
+
+
+export const GetMobilityRenewableShareDoc = gql`
+    query GetMobilityRenewableShare {
+  mobility(filter: {category: {_eq: "share_renewable"}}, limit: -1) {
+    period
+    region
+    value
+  }
+}
+    `;
+export const GetCountriesDoc = gql`
+    query GetCountries {
+  countries(limit: -1) {
+    id
+    name_de
+  }
+}
+    `;
+export const GetMobilityRenewableShare = (
+            options: Omit<
+              WatchQueryOptions<GetMobilityRenewableShareQueryVariables>, 
+              "query"
+            >
+          ): Readable<
+            ApolloQueryResult<GetMobilityRenewableShareQuery> & {
+              query: ObservableQuery<
+                GetMobilityRenewableShareQuery,
+                GetMobilityRenewableShareQueryVariables
+              >;
+            }
+          > => {
+            const q = client.watchQuery({
+              query: GetMobilityRenewableShareDoc,
+              ...options,
+            });
+            var result = readable<
+              ApolloQueryResult<GetMobilityRenewableShareQuery> & {
+                query: ObservableQuery<
+                  GetMobilityRenewableShareQuery,
+                  GetMobilityRenewableShareQueryVariables
+                >;
+              }
+            >(
+              { data: {} as any, loading: true, error: undefined, networkStatus: 1, query: q },
+              (set) => {
+                q.subscribe((v: any) => {
+                  set({ ...v, query: q });
+                });
+              }
+            );
+            return result;
+          }
+        
+              export const AsyncGetMobilityRenewableShare = (
+                options: Omit<
+                  QueryOptions<GetMobilityRenewableShareQueryVariables>,
+                  "query"
+                >
+              ) => {
+                return client.query<GetMobilityRenewableShareQuery>({query: GetMobilityRenewableShareDoc, ...options})
+              }
+            
+export const GetCountries = (
+            options: Omit<
+              WatchQueryOptions<GetCountriesQueryVariables>, 
+              "query"
+            >
+          ): Readable<
+            ApolloQueryResult<GetCountriesQuery> & {
+              query: ObservableQuery<
+                GetCountriesQuery,
+                GetCountriesQueryVariables
+              >;
+            }
+          > => {
+            const q = client.watchQuery({
+              query: GetCountriesDoc,
+              ...options,
+            });
+            var result = readable<
+              ApolloQueryResult<GetCountriesQuery> & {
+                query: ObservableQuery<
+                  GetCountriesQuery,
+                  GetCountriesQueryVariables
+                >;
+              }
+            >(
+              { data: {} as any, loading: true, error: undefined, networkStatus: 1, query: q },
+              (set) => {
+                q.subscribe((v: any) => {
+                  set({ ...v, query: q });
+                });
+              }
+            );
+            return result;
+          }
+        
+              export const AsyncGetCountries = (
+                options: Omit<
+                  QueryOptions<GetCountriesQueryVariables>,
+                  "query"
+                >
+              ) => {
+                return client.query<GetCountriesQuery>({query: GetCountriesDoc, ...options})
+              }
+            

--- a/src/lib/components/charts/custom/mobilityRenewableShare/getData.ts
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/getData.ts
@@ -1,0 +1,38 @@
+import getDirectusInstance from '$lib/utils/directus';
+import { readItems } from '@directus/sdk';
+import { safeParseMobilityRenewableShareData, safeParseCountriesData } from './schema';
+
+const directus = getDirectusInstance(fetch);
+
+export const getMobilityRenewableShare = async () => {
+	const data = await directus.request(
+		readItems('mobility', {
+			fields: ['period', 'region', 'value'],
+			filter: {
+				category: {
+					_eq: 'share_renewable'
+				}
+			},
+			limit: -1
+		})
+	);
+	const result = safeParseMobilityRenewableShareData(data);
+	if (!result.success) {
+		console.error('Validation error in getMobilityRenewableShare:', result.error);
+	}
+	return result.success ? result.data : [];
+};
+
+export const getCountries = async () => {
+	const data = await directus.request(
+		readItems('countries', {
+			fields: ['id', 'name_de'],
+			limit: -1
+		})
+	);
+	const result = safeParseCountriesData(data);
+	if (!result.success) {
+		console.error('Validation error in getCountries:', result.error);
+	}
+	return result.success ? result.data : [];
+};

--- a/src/lib/components/charts/custom/mobilityRenewableShare/index.svelte
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/index.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { getCountries, getMobilityRenewableShare } from './getData';
+	import ChartLine from '$lib/components/charts/chartLine.svelte';
+	import { onMount } from 'svelte';
+	import type { MobilityRenewableShare, Countries } from './schema';
+	import { transformDataForChart, type LineChartData } from './transformData';
+
+	let loading = true;
+	let error: Error | null = null;
+	let data: MobilityRenewableShare = [];
+	let countries: Countries = [];
+	let lineChartData: LineChartData = {
+		chartData: [],
+		keys: [],
+		labels: [],
+		colors: []
+	};
+
+	// Detect country from domain
+	let currentCountry = 'DE'; // Default to DE
+
+	function getCountryFromDomain(): string {
+		const hostname = window.location.hostname;
+		if (hostname.includes('.at')) {
+			return 'AT';
+		} else if (hostname.includes('.de')) {
+			return 'DE';
+		}
+		// Default fallback
+		return 'DE';
+	}
+
+	currentCountry = getCountryFromDomain();
+
+	onMount(async () => {
+		try {
+			loading = true;
+			const [mobilityData, countriesData] = await Promise.all([
+				getMobilityRenewableShare(),
+				getCountries()
+			]);
+
+			data = mobilityData;
+			countries = countriesData;
+			lineChartData = transformDataForChart(data, countries);
+		} catch (e) {
+			error = e as Error;
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<div class="w-full h-[400px] p-4">
+	{#if loading}
+		<div class="flex items-center justify-center h-full">
+			<p class="text-gray-500">Loading chart data...</p>
+		</div>
+	{:else if error}
+		<div class="flex items-center justify-center h-full">
+			<p class="text-red-500">Error loading chart data: {error.message}</p>
+		</div>
+	{:else if data && data.length > 0}
+		{#if lineChartData.chartData.length > 0}
+			{@const { chartData, keys, labels, colors } = lineChartData}
+			<ChartLine
+				data={chartData}
+				{keys}
+				{labels}
+				{colors}
+				visualisation="normal"
+				unit="%"
+				showAreas={false}
+				showDots={true}
+				showLegend={true}
+				lineWidth={2}
+				circleRadius={3}
+				xTicksInterval={2}
+				showTotal={false}
+			/>
+		{:else}
+			<div class="flex items-center justify-center h-full">
+				<p class="text-gray-500">No chart data available after transformation</p>
+			</div>
+		{/if}
+	{:else}
+		<div class="flex items-center justify-center h-full">
+			<p class="text-gray-500">No data available</p>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/charts/custom/mobilityRenewableShare/index.svelte
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/index.svelte
@@ -4,6 +4,11 @@
 	import { onMount } from 'svelte';
 	import type { MobilityRenewableShare, Countries } from './schema';
 	import { transformDataForChart, type LineChartData } from './transformData';
+	import {
+		AsyncGetMobilityRenewableShare,
+		GetCountries,
+		GetMobilityRenewableShare
+	} from './__generated__/mobilityRenewableShare.generated';
 
 	let loading = true;
 	let error: Error | null = null;
@@ -48,6 +53,19 @@
 		} finally {
 			loading = false;
 		}
+	});
+
+	// Test GraphQL data fetching
+	$: mobilityRenewableShare = GetMobilityRenewableShare({});
+	$: console.log('GraphQL mobilityRenewableShare', $mobilityRenewableShare.data.mobility);
+
+	$: graphQLcountries = GetCountries({});
+	$: console.log('GraphQL countries', $graphQLcountries.data.countries);
+
+	// Test async GraphQL data fetching
+	onMount(async () => {
+		const { data: mobilityData, error, loading } = await AsyncGetMobilityRenewableShare({});
+		console.log('Async mobilityRenewableShare', mobilityData, error, loading);
 	});
 </script>
 

--- a/src/lib/components/charts/custom/mobilityRenewableShare/mobilityRenewableShare.gql
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/mobilityRenewableShare.gql
@@ -1,0 +1,14 @@
+query GetMobilityRenewableShare {
+	mobility(filter: { category: { _eq: "share_renewable" } }, limit: -1) {
+		period
+		region
+		value
+	}
+}
+
+query GetCountries {
+	countries(limit: -1) {
+		id
+		name_de
+	}
+}

--- a/src/lib/components/charts/custom/mobilityRenewableShare/schema.ts
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/schema.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+// Define the schema for a single mobility renewable share data item
+export const MobilityRenewableShareItemSchema = z.object({
+	period: z.string().describe('The time period for the data point'),
+	region: z.string().describe('The geographic region for the data point'),
+	value: z.number().describe('The renewable share value as a number')
+});
+
+// Define the schema for the array of mobility renewable share data
+export const MobilityRenewableShareSchema = z.array(MobilityRenewableShareItemSchema);
+
+// Define the schema for a single country data item
+export const CountryItemSchema = z.object({
+	id: z.string().describe('The unique identifier for the country'),
+	name_de: z.string().describe('The German name of the country')
+});
+
+// Define the schema for the array of countries data
+export const CountriesSchema = z.array(CountryItemSchema);
+
+// Type definitions derived from the schemas
+export type MobilityRenewableShareItem = z.infer<typeof MobilityRenewableShareItemSchema>;
+export type MobilityRenewableShare = z.infer<typeof MobilityRenewableShareSchema>;
+export type CountryItem = z.infer<typeof CountryItemSchema>;
+export type Countries = z.infer<typeof CountriesSchema>;
+
+/**
+ * Validates the data returned from getMobilityRenewableShare
+ * @param data The data to validate
+ * @returns The validated data with proper typing
+ * @throws If validation fails
+ */
+export function validateMobilityRenewableShareData(data: unknown): MobilityRenewableShare {
+	return MobilityRenewableShareSchema.parse(data);
+}
+
+/**
+ * Safely validates the data returned from getMobilityRenewableShare
+ * @param data The data to validate
+ * @returns Result object with success status and either validated data or error
+ */
+export function safeParseMobilityRenewableShareData(data: unknown) {
+	return MobilityRenewableShareSchema.safeParse(data);
+}
+
+/**
+ * Validates the data returned from getCountries
+ * @param data The data to validate
+ * @returns The validated data with proper typing
+ * @throws If validation fails
+ */
+export function validateCountriesData(data: unknown): Countries {
+	return CountriesSchema.parse(data);
+}
+
+/**
+ * Safely validates the data returned from getCountries
+ * @param data The data to validate
+ * @returns Result object with success status and either validated data or error
+ */
+export function safeParseCountriesData(data: unknown) {
+	return CountriesSchema.safeParse(data);
+}

--- a/src/lib/components/charts/custom/mobilityRenewableShare/transformData.ts
+++ b/src/lib/components/charts/custom/mobilityRenewableShare/transformData.ts
@@ -1,0 +1,90 @@
+import type { MobilityRenewableShare, Countries } from './schema';
+
+const DEFAULT_COLOR = '#a3a3a3';
+
+// Define colors for different regions
+export const regionColors = {
+	DE: '#7CBAB3',
+	AT: '#575C75',
+	FR: '#71665B',
+	ES: '#B28834',
+	IT: '#8CAED9',
+	PT: '#E0A906',
+	GB: '#CF6317',
+	highlighted: '#1eaf90'
+};
+
+// Type for chart data structure
+export type LineChartData = {
+	chartData: Array<Record<string, any>>;
+	keys: string[];
+	labels: string[];
+	colors: string[];
+};
+
+/**
+ * Transforms API data into the format expected by the ChartLine component
+ * @param apiData Data from the Mobility API
+ * @param countries Countries data with region IDs and German names
+ * @param currentCountry The current country code based on the domain (DE or AT)
+ * @returns Formatted data for the chart component
+ */
+export function transformDataForChart(
+	apiData: MobilityRenewableShare,
+	countries: Countries = [],
+	currentCountry: string = 'DE'
+): LineChartData {
+	if (!apiData || apiData.length === 0) return { chartData: [], keys: [], labels: [], colors: [] };
+
+	// Get unique periods and regions
+	const periods = [...new Set(apiData.map((item) => item.period))].sort();
+	// Sort regions to ensure consistent ordering
+	const regions = [...new Set(apiData.map((item) => item.region))].sort((a, b) =>
+		a.localeCompare(b)
+	);
+
+	// Create a lookup map for quick access to values
+	const dataMap: Record<string, Record<string, number>> = {};
+	apiData.forEach((item) => {
+		if (!dataMap[item.period]) dataMap[item.period] = {};
+		dataMap[item.period][item.region] = item.value;
+	});
+
+	// Create chart data with the format expected by chartLine
+	const chartData = periods.map((period, index) => {
+		const dataPoint: Record<string, any> = {
+			x: index,
+			label: period
+		};
+
+		// Add each region as a property
+		regions.forEach((region) => {
+			dataPoint[region] = dataMap[period]?.[region] || NaN;
+		});
+
+		return dataPoint;
+	});
+
+	// Create colors array matching the regions order
+	const colors = regions.map((region) => {
+		// Use highlighted color for the current country
+		if (region === currentCountry) {
+			return regionColors.highlighted;
+		}
+		// Otherwise use the region's default color or gray if not defined
+		return regionColors[region as keyof typeof regionColors] ?? DEFAULT_COLOR;
+	});
+
+	// Create labels using country names when available
+	const labels = regions.map((region) => {
+		const country = countries.find((country) => country.id === region);
+		return country ? country.name_de : region;
+	});
+
+	return {
+		chartData,
+		keys: regions,
+		labels,
+		colors
+	};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10961 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  Date: { input: any; output: any; }
+  GraphQLBigInt: { input: any; output: any; }
+  GraphQLStringOrFloat: { input: any; output: any; }
+  JSON: { input: any; output: any; }
+};
+
+export enum EventEnum {
+  Create = 'create',
+  Delete = 'delete',
+  Update = 'update'
+}
+
+export type Query = {
+  __typename?: 'Query';
+  at_geosphere_data: Array<At_Geosphere_Data>;
+  at_geosphere_data_aggregated: Array<At_Geosphere_Data_Aggregated>;
+  at_geosphere_data_by_id?: Maybe<At_Geosphere_Data>;
+  at_geosphere_data_by_version?: Maybe<Version_At_Geosphere_Data>;
+  at_geosphere_stations: Array<At_Geosphere_Stations>;
+  at_geosphere_stations_aggregated: Array<At_Geosphere_Stations_Aggregated>;
+  at_geosphere_stations_by_id?: Maybe<At_Geosphere_Stations>;
+  at_geosphere_stations_by_version?: Maybe<Version_At_Geosphere_Stations>;
+  biomasse_produktion: Array<Biomasse_Produktion>;
+  biomasse_produktion_aggregated: Array<Biomasse_Produktion_Aggregated>;
+  biomasse_produktion_by_id?: Maybe<Biomasse_Produktion>;
+  biomasse_produktion_by_version?: Maybe<Version_Biomasse_Produktion>;
+  biomasse_zielpfad: Array<Biomasse_Zielpfad>;
+  biomasse_zielpfad_aggregated: Array<Biomasse_Zielpfad_Aggregated>;
+  biomasse_zielpfad_by_id?: Maybe<Biomasse_Zielpfad>;
+  biomasse_zielpfad_by_version?: Maybe<Version_Biomasse_Zielpfad>;
+  block_chart: Array<Block_Chart>;
+  block_chart_aggregated: Array<Block_Chart_Aggregated>;
+  block_chart_by_id?: Maybe<Block_Chart>;
+  block_chart_by_version?: Maybe<Version_Block_Chart>;
+  block_chart_charts: Array<Block_Chart_Charts>;
+  block_chart_charts_aggregated: Array<Block_Chart_Charts_Aggregated>;
+  block_chart_charts_by_id?: Maybe<Block_Chart_Charts>;
+  block_chart_charts_by_version?: Maybe<Version_Block_Chart_Charts>;
+  block_donation: Array<Block_Donation>;
+  block_donation_aggregated: Array<Block_Donation_Aggregated>;
+  block_donation_by_id?: Maybe<Block_Donation>;
+  block_donation_by_version?: Maybe<Version_Block_Donation>;
+  block_donation_translations: Array<Block_Donation_Translations>;
+  block_donation_translations_aggregated: Array<Block_Donation_Translations_Aggregated>;
+  block_donation_translations_by_id?: Maybe<Block_Donation_Translations>;
+  block_donation_translations_by_version?: Maybe<Version_Block_Donation_Translations>;
+  block_gallery: Array<Block_Gallery>;
+  block_gallery_aggregated: Array<Block_Gallery_Aggregated>;
+  block_gallery_by_id?: Maybe<Block_Gallery>;
+  block_gallery_by_version?: Maybe<Version_Block_Gallery>;
+  block_gallery_files: Array<Block_Gallery_Files>;
+  block_gallery_files_aggregated: Array<Block_Gallery_Files_Aggregated>;
+  block_gallery_files_by_id?: Maybe<Block_Gallery_Files>;
+  block_gallery_files_by_version?: Maybe<Version_Block_Gallery_Files>;
+  block_grid: Array<Block_Grid>;
+  block_grid_aggregated: Array<Block_Grid_Aggregated>;
+  block_grid_blocks: Array<Block_Grid_Blocks>;
+  block_grid_blocks_aggregated: Array<Block_Grid_Blocks_Aggregated>;
+  block_grid_blocks_by_id?: Maybe<Block_Grid_Blocks>;
+  block_grid_blocks_by_version?: Maybe<Version_Block_Grid_Blocks>;
+  block_grid_by_id?: Maybe<Block_Grid>;
+  block_grid_by_version?: Maybe<Version_Block_Grid>;
+  block_items: Array<Block_Items>;
+  block_items_aggregated: Array<Block_Items_Aggregated>;
+  block_items_by_id?: Maybe<Block_Items>;
+  block_items_by_version?: Maybe<Version_Block_Items>;
+  block_items_translations: Array<Block_Items_Translations>;
+  block_items_translations_aggregated: Array<Block_Items_Translations_Aggregated>;
+  block_items_translations_by_id?: Maybe<Block_Items_Translations>;
+  block_items_translations_by_version?: Maybe<Version_Block_Items_Translations>;
+  block_news: Array<Block_News>;
+  block_news_aggregated: Array<Block_News_Aggregated>;
+  block_news_by_id?: Maybe<Block_News>;
+  block_news_by_version?: Maybe<Version_Block_News>;
+  block_panel: Array<Block_Panel>;
+  block_panel_aggregated: Array<Block_Panel_Aggregated>;
+  block_panel_by_id?: Maybe<Block_Panel>;
+  block_panel_by_version?: Maybe<Version_Block_Panel>;
+  block_panel_translations: Array<Block_Panel_Translations>;
+  block_panel_translations_aggregated: Array<Block_Panel_Translations_Aggregated>;
+  block_panel_translations_by_id?: Maybe<Block_Panel_Translations>;
+  block_panel_translations_by_version?: Maybe<Version_Block_Panel_Translations>;
+  block_quiz: Array<Block_Quiz>;
+  block_quiz_aggregated: Array<Block_Quiz_Aggregated>;
+  block_quiz_by_id?: Maybe<Block_Quiz>;
+  block_quiz_by_version?: Maybe<Version_Block_Quiz>;
+  block_quotes: Array<Block_Quotes>;
+  block_quotes_aggregated: Array<Block_Quotes_Aggregated>;
+  block_quotes_by_id?: Maybe<Block_Quotes>;
+  block_quotes_by_version?: Maybe<Version_Block_Quotes>;
+  block_richtext: Array<Block_Richtext>;
+  block_richtext_aggregated: Array<Block_Richtext_Aggregated>;
+  block_richtext_by_id?: Maybe<Block_Richtext>;
+  block_richtext_by_version?: Maybe<Version_Block_Richtext>;
+  block_richtext_translations: Array<Block_Richtext_Translations>;
+  block_richtext_translations_aggregated: Array<Block_Richtext_Translations_Aggregated>;
+  block_richtext_translations_by_id?: Maybe<Block_Richtext_Translations>;
+  block_richtext_translations_by_version?: Maybe<Version_Block_Richtext_Translations>;
+  block_teaser: Array<Block_Teaser>;
+  block_teaser_aggregated: Array<Block_Teaser_Aggregated>;
+  block_teaser_by_id?: Maybe<Block_Teaser>;
+  block_teaser_by_version?: Maybe<Version_Block_Teaser>;
+  block_teaser_translations: Array<Block_Teaser_Translations>;
+  block_teaser_translations_aggregated: Array<Block_Teaser_Translations_Aggregated>;
+  block_teaser_translations_by_id?: Maybe<Block_Teaser_Translations>;
+  block_teaser_translations_by_version?: Maybe<Version_Block_Teaser_Translations>;
+  block_toggle: Array<Block_Toggle>;
+  block_toggle_aggregated: Array<Block_Toggle_Aggregated>;
+  block_toggle_by_id?: Maybe<Block_Toggle>;
+  block_toggle_by_version?: Maybe<Version_Block_Toggle>;
+  block_toggle_translations: Array<Block_Toggle_Translations>;
+  block_toggle_translations_aggregated: Array<Block_Toggle_Translations_Aggregated>;
+  block_toggle_translations_by_id?: Maybe<Block_Toggle_Translations>;
+  block_toggle_translations_by_version?: Maybe<Version_Block_Toggle_Translations>;
+  carbon_prices: Array<Carbon_Prices>;
+  carbon_prices_aggregated: Array<Carbon_Prices_Aggregated>;
+  carbon_prices_by_id?: Maybe<Carbon_Prices>;
+  carbon_prices_by_version?: Maybe<Version_Carbon_Prices>;
+  charts: Array<Charts>;
+  charts_aggregated: Array<Charts_Aggregated>;
+  charts_by_id?: Maybe<Charts>;
+  charts_by_version?: Maybe<Version_Charts>;
+  charts_translations: Array<Charts_Translations>;
+  charts_translations_aggregated: Array<Charts_Translations_Aggregated>;
+  charts_translations_by_id?: Maybe<Charts_Translations>;
+  charts_translations_by_version?: Maybe<Version_Charts_Translations>;
+  companies: Array<Companies>;
+  companies_aggregated: Array<Companies_Aggregated>;
+  companies_by_id?: Maybe<Companies>;
+  companies_by_version?: Maybe<Version_Companies>;
+  companies_companies_sectors: Array<Companies_Companies_Sectors>;
+  companies_companies_sectors_aggregated: Array<Companies_Companies_Sectors_Aggregated>;
+  companies_companies_sectors_by_id?: Maybe<Companies_Companies_Sectors>;
+  companies_companies_sectors_by_version?: Maybe<Version_Companies_Companies_Sectors>;
+  companies_emissions: Array<Companies_Emissions>;
+  companies_emissions_aggregated: Array<Companies_Emissions_Aggregated>;
+  companies_emissions_by_id?: Maybe<Companies_Emissions>;
+  companies_emissions_by_version?: Maybe<Version_Companies_Emissions>;
+  companies_sectors: Array<Companies_Sectors>;
+  companies_sectors_aggregated: Array<Companies_Sectors_Aggregated>;
+  companies_sectors_by_id?: Maybe<Companies_Sectors>;
+  companies_sectors_by_version?: Maybe<Version_Companies_Sectors>;
+  countries: Array<Countries>;
+  countries_aggregated: Array<Countries_Aggregated>;
+  countries_by_id?: Maybe<Countries>;
+  countries_by_version?: Maybe<Version_Countries>;
+  datasets: Array<Datasets>;
+  datasets_aggregated: Array<Datasets_Aggregated>;
+  datasets_by_id?: Maybe<Datasets>;
+  datasets_by_version?: Maybe<Version_Datasets>;
+  de_dwd_data: Array<De_Dwd_Data>;
+  de_dwd_data_aggregated: Array<De_Dwd_Data_Aggregated>;
+  de_dwd_data_by_id?: Maybe<De_Dwd_Data>;
+  de_dwd_data_by_version?: Maybe<Version_De_Dwd_Data>;
+  de_dwd_stations: Array<De_Dwd_Stations>;
+  de_dwd_stations_aggregated: Array<De_Dwd_Stations_Aggregated>;
+  de_dwd_stations_by_id?: Maybe<De_Dwd_Stations>;
+  de_dwd_stations_by_version?: Maybe<Version_De_Dwd_Stations>;
+  ee_goals: Array<Ee_Goals>;
+  ee_goals_aggregated: Array<Ee_Goals_Aggregated>;
+  ee_goals_by_id?: Maybe<Ee_Goals>;
+  ee_goals_by_version?: Maybe<Version_Ee_Goals>;
+  ee_historisch: Array<Ee_Historisch>;
+  ee_historisch_aggregated: Array<Ee_Historisch_Aggregated>;
+  ee_historisch_by_id?: Maybe<Ee_Historisch>;
+  ee_historisch_by_version?: Maybe<Version_Ee_Historisch>;
+  ee_potentiale: Array<Ee_Potentiale>;
+  ee_potentiale_aggregated: Array<Ee_Potentiale_Aggregated>;
+  ee_potentiale_by_id?: Maybe<Ee_Potentiale>;
+  ee_potentiale_by_version?: Maybe<Version_Ee_Potentiale>;
+  ee_produktion: Array<Ee_Produktion>;
+  ee_produktion_aggregated: Array<Ee_Produktion_Aggregated>;
+  ee_produktion_by_id?: Maybe<Ee_Produktion>;
+  ee_produktion_by_version?: Maybe<Version_Ee_Produktion>;
+  ee_zielpfad: Array<Ee_Zielpfad>;
+  ee_zielpfad_aggregated: Array<Ee_Zielpfad_Aggregated>;
+  ee_zielpfad_by_id?: Maybe<Ee_Zielpfad>;
+  ee_zielpfad_by_version?: Maybe<Version_Ee_Zielpfad>;
+  emissions: Array<Emissions>;
+  emissions_aggregated: Array<Emissions_Aggregated>;
+  emissions_by_id?: Maybe<Emissions>;
+  emissions_by_version?: Maybe<Version_Emissions>;
+  energy: Array<Energy>;
+  energy_aggregated: Array<Energy_Aggregated>;
+  energy_by_id?: Maybe<Energy>;
+  energy_by_version?: Maybe<Version_Energy>;
+  energy_renewable_share: Array<Energy_Renewable_Share>;
+  energy_renewable_share_aggregated: Array<Energy_Renewable_Share_Aggregated>;
+  energy_renewable_share_by_id?: Maybe<Energy_Renewable_Share>;
+  energy_renewable_share_by_version?: Maybe<Version_Energy_Renewable_Share>;
+  erneuerbare_2030_scenarios: Array<Erneuerbare_2030_Scenarios>;
+  erneuerbare_2030_scenarios_aggregated: Array<Erneuerbare_2030_Scenarios_Aggregated>;
+  erneuerbare_2030_scenarios_by_id?: Maybe<Erneuerbare_2030_Scenarios>;
+  erneuerbare_2030_scenarios_by_version?: Maybe<Version_Erneuerbare_2030_Scenarios>;
+  gas_imports: Array<Gas_Imports>;
+  gas_imports_aggregated: Array<Gas_Imports_Aggregated>;
+  gas_imports_by_id?: Maybe<Gas_Imports>;
+  gas_imports_by_version?: Maybe<Version_Gas_Imports>;
+  global_co2_concentration: Array<Global_Co2_Concentration>;
+  global_co2_concentration_aggregated: Array<Global_Co2_Concentration_Aggregated>;
+  global_co2_concentration_by_id?: Maybe<Global_Co2_Concentration>;
+  global_co2_concentration_by_version?: Maybe<Version_Global_Co2_Concentration>;
+  glossary: Array<Glossary>;
+  glossary_aggregated: Array<Glossary_Aggregated>;
+  glossary_by_id?: Maybe<Glossary>;
+  glossary_by_version?: Maybe<Version_Glossary>;
+  glossary_translations: Array<Glossary_Translations>;
+  glossary_translations_aggregated: Array<Glossary_Translations_Aggregated>;
+  glossary_translations_by_id?: Maybe<Glossary_Translations>;
+  glossary_translations_by_version?: Maybe<Version_Glossary_Translations>;
+  languages: Array<Languages>;
+  languages_aggregated: Array<Languages_Aggregated>;
+  languages_by_id?: Maybe<Languages>;
+  languages_by_version?: Maybe<Version_Languages>;
+  mobility: Array<Mobility>;
+  mobility_aggregated: Array<Mobility_Aggregated>;
+  mobility_by_id?: Maybe<Mobility>;
+  mobility_by_version?: Maybe<Version_Mobility>;
+  mobility_cars: Array<Mobility_Cars>;
+  mobility_cars_aggregated: Array<Mobility_Cars_Aggregated>;
+  mobility_cars_by_id?: Maybe<Mobility_Cars>;
+  mobility_cars_by_version?: Maybe<Version_Mobility_Cars>;
+  news: Array<News>;
+  news_aggregated: Array<News_Aggregated>;
+  news_by_id?: Maybe<News>;
+  news_by_version?: Maybe<Version_News>;
+  news_translations: Array<News_Translations>;
+  news_translations_aggregated: Array<News_Translations_Aggregated>;
+  news_translations_by_id?: Maybe<News_Translations>;
+  news_translations_by_version?: Maybe<Version_News_Translations>;
+  pages: Array<Pages>;
+  pages_aggregated: Array<Pages_Aggregated>;
+  pages_blocks: Array<Pages_Blocks>;
+  pages_blocks_aggregated: Array<Pages_Blocks_Aggregated>;
+  pages_blocks_by_id?: Maybe<Pages_Blocks>;
+  pages_blocks_by_version?: Maybe<Version_Pages_Blocks>;
+  pages_by_id?: Maybe<Pages>;
+  pages_by_version?: Maybe<Version_Pages>;
+  pages_translations: Array<Pages_Translations>;
+  pages_translations_aggregated: Array<Pages_Translations_Aggregated>;
+  pages_translations_blocks: Array<Pages_Translations_Blocks>;
+  pages_translations_blocks_aggregated: Array<Pages_Translations_Blocks_Aggregated>;
+  pages_translations_blocks_by_id?: Maybe<Pages_Translations_Blocks>;
+  pages_translations_blocks_by_version?: Maybe<Version_Pages_Translations_Blocks>;
+  pages_translations_by_id?: Maybe<Pages_Translations>;
+  pages_translations_by_version?: Maybe<Version_Pages_Translations>;
+  policies: Array<Policies>;
+  policies_aggregated: Array<Policies_Aggregated>;
+  policies_attributes: Array<Policies_Attributes>;
+  policies_attributes_aggregated: Array<Policies_Attributes_Aggregated>;
+  policies_attributes_by_id?: Maybe<Policies_Attributes>;
+  policies_attributes_by_version?: Maybe<Version_Policies_Attributes>;
+  policies_attributes_translations: Array<Policies_Attributes_Translations>;
+  policies_attributes_translations_aggregated: Array<Policies_Attributes_Translations_Aggregated>;
+  policies_attributes_translations_by_id?: Maybe<Policies_Attributes_Translations>;
+  policies_attributes_translations_by_version?: Maybe<Version_Policies_Attributes_Translations>;
+  policies_by_id?: Maybe<Policies>;
+  policies_by_version?: Maybe<Version_Policies>;
+  policies_policies_attributes: Array<Policies_Policies_Attributes>;
+  policies_policies_attributes_aggregated: Array<Policies_Policies_Attributes_Aggregated>;
+  policies_policies_attributes_by_id?: Maybe<Policies_Policies_Attributes>;
+  policies_policies_attributes_by_version?: Maybe<Version_Policies_Policies_Attributes>;
+  policies_stakeholders: Array<Policies_Stakeholders>;
+  policies_stakeholders_aggregated: Array<Policies_Stakeholders_Aggregated>;
+  policies_stakeholders_by_id?: Maybe<Policies_Stakeholders>;
+  policies_stakeholders_by_version?: Maybe<Version_Policies_Stakeholders>;
+  policies_status: Array<Policies_Status>;
+  policies_status_aggregated: Array<Policies_Status_Aggregated>;
+  policies_status_by_id?: Maybe<Policies_Status>;
+  policies_status_by_version?: Maybe<Version_Policies_Status>;
+  policies_status_translations: Array<Policies_Status_Translations>;
+  policies_status_translations_aggregated: Array<Policies_Status_Translations_Aggregated>;
+  policies_status_translations_by_id?: Maybe<Policies_Status_Translations>;
+  policies_status_translations_by_version?: Maybe<Version_Policies_Status_Translations>;
+  policies_translations: Array<Policies_Translations>;
+  policies_translations_aggregated: Array<Policies_Translations_Aggregated>;
+  policies_translations_by_id?: Maybe<Policies_Translations>;
+  policies_translations_by_version?: Maybe<Version_Policies_Translations>;
+  policies_updates: Array<Policies_Updates>;
+  policies_updates_aggregated: Array<Policies_Updates_Aggregated>;
+  policies_updates_by_id?: Maybe<Policies_Updates>;
+  policies_updates_by_version?: Maybe<Version_Policies_Updates>;
+  policies_updates_translations: Array<Policies_Updates_Translations>;
+  policies_updates_translations_aggregated: Array<Policies_Updates_Translations_Aggregated>;
+  policies_updates_translations_by_id?: Maybe<Policies_Updates_Translations>;
+  policies_updates_translations_by_version?: Maybe<Version_Policies_Updates_Translations>;
+  pv_produktion: Array<Pv_Produktion>;
+  pv_produktion_aggregated: Array<Pv_Produktion_Aggregated>;
+  pv_produktion_by_id?: Maybe<Pv_Produktion>;
+  pv_produktion_by_version?: Maybe<Version_Pv_Produktion>;
+  pv_zielpfad: Array<Pv_Zielpfad>;
+  pv_zielpfad_aggregated: Array<Pv_Zielpfad_Aggregated>;
+  pv_zielpfad_by_id?: Maybe<Pv_Zielpfad>;
+  pv_zielpfad_by_version?: Maybe<Version_Pv_Zielpfad>;
+  quiz_answers: Array<Quiz_Answers>;
+  quiz_answers_aggregated: Array<Quiz_Answers_Aggregated>;
+  quiz_answers_by_id?: Maybe<Quiz_Answers>;
+  quiz_answers_by_version?: Maybe<Version_Quiz_Answers>;
+  quiz_questions: Array<Quiz_Questions>;
+  quiz_questions_aggregated: Array<Quiz_Questions_Aggregated>;
+  quiz_questions_by_id?: Maybe<Quiz_Questions>;
+  quiz_questions_by_version?: Maybe<Version_Quiz_Questions>;
+  quotes: Array<Quotes>;
+  quotes_aggregated: Array<Quotes_Aggregated>;
+  quotes_by_id?: Maybe<Quotes>;
+  quotes_by_version?: Maybe<Version_Quotes>;
+  regions: Array<Regions>;
+  regions_aggregated: Array<Regions_Aggregated>;
+  regions_by_id?: Maybe<Regions>;
+  regions_by_version?: Maybe<Version_Regions>;
+  renewable_share_15min: Array<Renewable_Share_15min>;
+  renewable_share_15min_aggregated: Array<Renewable_Share_15min_Aggregated>;
+  renewable_share_15min_by_id?: Maybe<Renewable_Share_15min>;
+  renewable_share_15min_by_version?: Maybe<Version_Renewable_Share_15min>;
+  renewable_share_daily: Array<Renewable_Share_Daily>;
+  renewable_share_daily_aggregated: Array<Renewable_Share_Daily_Aggregated>;
+  renewable_share_daily_by_id?: Maybe<Renewable_Share_Daily>;
+  renewable_share_daily_by_version?: Maybe<Version_Renewable_Share_Daily>;
+  seo: Array<Seo>;
+  seo_aggregated: Array<Seo_Aggregated>;
+  seo_by_id?: Maybe<Seo>;
+  seo_by_version?: Maybe<Version_Seo>;
+  sites: Array<Sites>;
+  sites_aggregated: Array<Sites_Aggregated>;
+  sites_by_id?: Maybe<Sites>;
+  sites_by_version?: Maybe<Version_Sites>;
+  sites_translations: Array<Sites_Translations>;
+  sites_translations_aggregated: Array<Sites_Translations_Aggregated>;
+  sites_translations_by_id?: Maybe<Sites_Translations>;
+  sites_translations_by_version?: Maybe<Version_Sites_Translations>;
+  stakeholders: Array<Stakeholders>;
+  stakeholders_aggregated: Array<Stakeholders_Aggregated>;
+  stakeholders_by_id?: Maybe<Stakeholders>;
+  stakeholders_by_version?: Maybe<Version_Stakeholders>;
+  wasserkraft_produktion: Array<Wasserkraft_Produktion>;
+  wasserkraft_produktion_aggregated: Array<Wasserkraft_Produktion_Aggregated>;
+  wasserkraft_produktion_by_id?: Maybe<Wasserkraft_Produktion>;
+  wasserkraft_produktion_by_version?: Maybe<Version_Wasserkraft_Produktion>;
+  wasserkraft_zielpfad: Array<Wasserkraft_Zielpfad>;
+  wasserkraft_zielpfad_aggregated: Array<Wasserkraft_Zielpfad_Aggregated>;
+  wasserkraft_zielpfad_by_id?: Maybe<Wasserkraft_Zielpfad>;
+  wasserkraft_zielpfad_by_version?: Maybe<Version_Wasserkraft_Zielpfad>;
+  windkraft_produktion: Array<Windkraft_Produktion>;
+  windkraft_produktion_aggregated: Array<Windkraft_Produktion_Aggregated>;
+  windkraft_produktion_by_id?: Maybe<Windkraft_Produktion>;
+  windkraft_produktion_by_version?: Maybe<Version_Windkraft_Produktion>;
+  windkraft_zielpfad: Array<Windkraft_Zielpfad>;
+  windkraft_zielpfad_aggregated: Array<Windkraft_Zielpfad_Aggregated>;
+  windkraft_zielpfad_by_id?: Maybe<Windkraft_Zielpfad>;
+  windkraft_zielpfad_by_version?: Maybe<Version_Windkraft_Zielpfad>;
+};
+
+
+export type QueryAt_Geosphere_DataArgs = {
+  filter?: InputMaybe<At_Geosphere_Data_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryAt_Geosphere_Data_AggregatedArgs = {
+  filter?: InputMaybe<At_Geosphere_Data_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryAt_Geosphere_Data_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryAt_Geosphere_Data_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryAt_Geosphere_StationsArgs = {
+  filter?: InputMaybe<At_Geosphere_Stations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryAt_Geosphere_Stations_AggregatedArgs = {
+  filter?: InputMaybe<At_Geosphere_Stations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryAt_Geosphere_Stations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryAt_Geosphere_Stations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBiomasse_ProduktionArgs = {
+  filter?: InputMaybe<Biomasse_Produktion_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBiomasse_Produktion_AggregatedArgs = {
+  filter?: InputMaybe<Biomasse_Produktion_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBiomasse_Produktion_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBiomasse_Produktion_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBiomasse_ZielpfadArgs = {
+  filter?: InputMaybe<Biomasse_Zielpfad_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBiomasse_Zielpfad_AggregatedArgs = {
+  filter?: InputMaybe<Biomasse_Zielpfad_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBiomasse_Zielpfad_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBiomasse_Zielpfad_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_ChartArgs = {
+  filter?: InputMaybe<Block_Chart_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Chart_AggregatedArgs = {
+  filter?: InputMaybe<Block_Chart_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Chart_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Chart_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Chart_ChartsArgs = {
+  filter?: InputMaybe<Block_Chart_Charts_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Chart_Charts_AggregatedArgs = {
+  filter?: InputMaybe<Block_Chart_Charts_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Chart_Charts_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Chart_Charts_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_DonationArgs = {
+  filter?: InputMaybe<Block_Donation_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Donation_AggregatedArgs = {
+  filter?: InputMaybe<Block_Donation_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Donation_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Donation_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Donation_TranslationsArgs = {
+  filter?: InputMaybe<Block_Donation_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Donation_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Block_Donation_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Donation_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Donation_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_GalleryArgs = {
+  filter?: InputMaybe<Block_Gallery_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Gallery_AggregatedArgs = {
+  filter?: InputMaybe<Block_Gallery_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Gallery_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Gallery_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Gallery_FilesArgs = {
+  filter?: InputMaybe<Block_Gallery_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Gallery_Files_AggregatedArgs = {
+  filter?: InputMaybe<Block_Gallery_Files_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Gallery_Files_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Gallery_Files_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_GridArgs = {
+  filter?: InputMaybe<Block_Grid_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Grid_AggregatedArgs = {
+  filter?: InputMaybe<Block_Grid_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Grid_BlocksArgs = {
+  filter?: InputMaybe<Block_Grid_Blocks_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Grid_Blocks_AggregatedArgs = {
+  filter?: InputMaybe<Block_Grid_Blocks_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Grid_Blocks_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Grid_Blocks_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Grid_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Grid_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_ItemsArgs = {
+  filter?: InputMaybe<Block_Items_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Items_AggregatedArgs = {
+  filter?: InputMaybe<Block_Items_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Items_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Items_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Items_TranslationsArgs = {
+  filter?: InputMaybe<Block_Items_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Items_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Block_Items_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Items_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Items_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_NewsArgs = {
+  filter?: InputMaybe<Block_News_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_News_AggregatedArgs = {
+  filter?: InputMaybe<Block_News_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_News_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_News_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_PanelArgs = {
+  filter?: InputMaybe<Block_Panel_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Panel_AggregatedArgs = {
+  filter?: InputMaybe<Block_Panel_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Panel_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Panel_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Panel_TranslationsArgs = {
+  filter?: InputMaybe<Block_Panel_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Panel_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Block_Panel_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Panel_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Panel_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_QuizArgs = {
+  filter?: InputMaybe<Block_Quiz_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Quiz_AggregatedArgs = {
+  filter?: InputMaybe<Block_Quiz_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Quiz_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Quiz_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_QuotesArgs = {
+  filter?: InputMaybe<Block_Quotes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Quotes_AggregatedArgs = {
+  filter?: InputMaybe<Block_Quotes_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Quotes_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Quotes_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_RichtextArgs = {
+  filter?: InputMaybe<Block_Richtext_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Richtext_AggregatedArgs = {
+  filter?: InputMaybe<Block_Richtext_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Richtext_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Richtext_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Richtext_TranslationsArgs = {
+  filter?: InputMaybe<Block_Richtext_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Richtext_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Block_Richtext_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Richtext_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Richtext_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_TeaserArgs = {
+  filter?: InputMaybe<Block_Teaser_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Teaser_AggregatedArgs = {
+  filter?: InputMaybe<Block_Teaser_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Teaser_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Teaser_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Teaser_TranslationsArgs = {
+  filter?: InputMaybe<Block_Teaser_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Teaser_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Block_Teaser_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Teaser_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Teaser_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_ToggleArgs = {
+  filter?: InputMaybe<Block_Toggle_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Toggle_AggregatedArgs = {
+  filter?: InputMaybe<Block_Toggle_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Toggle_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Toggle_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryBlock_Toggle_TranslationsArgs = {
+  filter?: InputMaybe<Block_Toggle_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Toggle_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Block_Toggle_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBlock_Toggle_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlock_Toggle_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCarbon_PricesArgs = {
+  filter?: InputMaybe<Carbon_Prices_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCarbon_Prices_AggregatedArgs = {
+  filter?: InputMaybe<Carbon_Prices_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCarbon_Prices_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCarbon_Prices_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryChartsArgs = {
+  filter?: InputMaybe<Charts_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCharts_AggregatedArgs = {
+  filter?: InputMaybe<Charts_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCharts_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCharts_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCharts_TranslationsArgs = {
+  filter?: InputMaybe<Charts_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCharts_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Charts_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCharts_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCharts_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCompaniesArgs = {
+  filter?: InputMaybe<Companies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_AggregatedArgs = {
+  filter?: InputMaybe<Companies_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCompanies_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCompanies_Companies_SectorsArgs = {
+  filter?: InputMaybe<Companies_Companies_Sectors_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_Companies_Sectors_AggregatedArgs = {
+  filter?: InputMaybe<Companies_Companies_Sectors_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_Companies_Sectors_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCompanies_Companies_Sectors_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCompanies_EmissionsArgs = {
+  filter?: InputMaybe<Companies_Emissions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_Emissions_AggregatedArgs = {
+  filter?: InputMaybe<Companies_Emissions_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_Emissions_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCompanies_Emissions_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCompanies_SectorsArgs = {
+  filter?: InputMaybe<Companies_Sectors_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_Sectors_AggregatedArgs = {
+  filter?: InputMaybe<Companies_Sectors_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCompanies_Sectors_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCompanies_Sectors_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryCountriesArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCountries_AggregatedArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryCountries_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCountries_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryDatasetsArgs = {
+  filter?: InputMaybe<Datasets_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDatasets_AggregatedArgs = {
+  filter?: InputMaybe<Datasets_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDatasets_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryDatasets_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryDe_Dwd_DataArgs = {
+  filter?: InputMaybe<De_Dwd_Data_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDe_Dwd_Data_AggregatedArgs = {
+  filter?: InputMaybe<De_Dwd_Data_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDe_Dwd_Data_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryDe_Dwd_Data_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryDe_Dwd_StationsArgs = {
+  filter?: InputMaybe<De_Dwd_Stations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDe_Dwd_Stations_AggregatedArgs = {
+  filter?: InputMaybe<De_Dwd_Stations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDe_Dwd_Stations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryDe_Dwd_Stations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEe_GoalsArgs = {
+  filter?: InputMaybe<Ee_Goals_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Goals_AggregatedArgs = {
+  filter?: InputMaybe<Ee_Goals_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Goals_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEe_Goals_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEe_HistorischArgs = {
+  filter?: InputMaybe<Ee_Historisch_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Historisch_AggregatedArgs = {
+  filter?: InputMaybe<Ee_Historisch_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Historisch_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEe_Historisch_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEe_PotentialeArgs = {
+  filter?: InputMaybe<Ee_Potentiale_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Potentiale_AggregatedArgs = {
+  filter?: InputMaybe<Ee_Potentiale_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Potentiale_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEe_Potentiale_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEe_ProduktionArgs = {
+  filter?: InputMaybe<Ee_Produktion_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Produktion_AggregatedArgs = {
+  filter?: InputMaybe<Ee_Produktion_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Produktion_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEe_Produktion_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEe_ZielpfadArgs = {
+  filter?: InputMaybe<Ee_Zielpfad_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Zielpfad_AggregatedArgs = {
+  filter?: InputMaybe<Ee_Zielpfad_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEe_Zielpfad_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEe_Zielpfad_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEmissionsArgs = {
+  filter?: InputMaybe<Emissions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEmissions_AggregatedArgs = {
+  filter?: InputMaybe<Emissions_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEmissions_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEmissions_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEnergyArgs = {
+  filter?: InputMaybe<Energy_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEnergy_AggregatedArgs = {
+  filter?: InputMaybe<Energy_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEnergy_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEnergy_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryEnergy_Renewable_ShareArgs = {
+  filter?: InputMaybe<Energy_Renewable_Share_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEnergy_Renewable_Share_AggregatedArgs = {
+  filter?: InputMaybe<Energy_Renewable_Share_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryEnergy_Renewable_Share_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryEnergy_Renewable_Share_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryErneuerbare_2030_ScenariosArgs = {
+  filter?: InputMaybe<Erneuerbare_2030_Scenarios_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryErneuerbare_2030_Scenarios_AggregatedArgs = {
+  filter?: InputMaybe<Erneuerbare_2030_Scenarios_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryErneuerbare_2030_Scenarios_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryErneuerbare_2030_Scenarios_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryGas_ImportsArgs = {
+  filter?: InputMaybe<Gas_Imports_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGas_Imports_AggregatedArgs = {
+  filter?: InputMaybe<Gas_Imports_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGas_Imports_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryGas_Imports_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryGlobal_Co2_ConcentrationArgs = {
+  filter?: InputMaybe<Global_Co2_Concentration_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGlobal_Co2_Concentration_AggregatedArgs = {
+  filter?: InputMaybe<Global_Co2_Concentration_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGlobal_Co2_Concentration_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryGlobal_Co2_Concentration_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryGlossaryArgs = {
+  filter?: InputMaybe<Glossary_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGlossary_AggregatedArgs = {
+  filter?: InputMaybe<Glossary_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGlossary_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryGlossary_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryGlossary_TranslationsArgs = {
+  filter?: InputMaybe<Glossary_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGlossary_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Glossary_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryGlossary_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryGlossary_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryLanguagesArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryLanguages_AggregatedArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryLanguages_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryLanguages_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryMobilityArgs = {
+  filter?: InputMaybe<Mobility_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryMobility_AggregatedArgs = {
+  filter?: InputMaybe<Mobility_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryMobility_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryMobility_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryMobility_CarsArgs = {
+  filter?: InputMaybe<Mobility_Cars_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryMobility_Cars_AggregatedArgs = {
+  filter?: InputMaybe<Mobility_Cars_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryMobility_Cars_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryMobility_Cars_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryNewsArgs = {
+  filter?: InputMaybe<News_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryNews_AggregatedArgs = {
+  filter?: InputMaybe<News_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryNews_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryNews_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryNews_TranslationsArgs = {
+  filter?: InputMaybe<News_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryNews_Translations_AggregatedArgs = {
+  filter?: InputMaybe<News_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryNews_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryNews_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPagesArgs = {
+  filter?: InputMaybe<Pages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_AggregatedArgs = {
+  filter?: InputMaybe<Pages_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_BlocksArgs = {
+  filter?: InputMaybe<Pages_Blocks_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_Blocks_AggregatedArgs = {
+  filter?: InputMaybe<Pages_Blocks_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_Blocks_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPages_Blocks_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPages_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPages_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPages_TranslationsArgs = {
+  filter?: InputMaybe<Pages_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Pages_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_Translations_BlocksArgs = {
+  filter?: InputMaybe<Pages_Translations_Blocks_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_Translations_Blocks_AggregatedArgs = {
+  filter?: InputMaybe<Pages_Translations_Blocks_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPages_Translations_Blocks_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPages_Translations_Blocks_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPages_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPages_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPoliciesArgs = {
+  filter?: InputMaybe<Policies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_AttributesArgs = {
+  filter?: InputMaybe<Policies_Attributes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Attributes_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Attributes_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Attributes_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Attributes_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_Attributes_TranslationsArgs = {
+  filter?: InputMaybe<Policies_Attributes_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Attributes_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Attributes_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Attributes_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Attributes_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_Policies_AttributesArgs = {
+  filter?: InputMaybe<Policies_Policies_Attributes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Policies_Attributes_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Policies_Attributes_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Policies_Attributes_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Policies_Attributes_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_StakeholdersArgs = {
+  filter?: InputMaybe<Policies_Stakeholders_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Stakeholders_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Stakeholders_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Stakeholders_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Stakeholders_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_StatusArgs = {
+  filter?: InputMaybe<Policies_Status_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Status_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Status_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Status_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Status_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_Status_TranslationsArgs = {
+  filter?: InputMaybe<Policies_Status_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Status_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Status_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Status_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Status_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_TranslationsArgs = {
+  filter?: InputMaybe<Policies_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_UpdatesArgs = {
+  filter?: InputMaybe<Policies_Updates_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Updates_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Updates_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Updates_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Updates_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPolicies_Updates_TranslationsArgs = {
+  filter?: InputMaybe<Policies_Updates_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Updates_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Policies_Updates_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPolicies_Updates_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPolicies_Updates_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPv_ProduktionArgs = {
+  filter?: InputMaybe<Pv_Produktion_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPv_Produktion_AggregatedArgs = {
+  filter?: InputMaybe<Pv_Produktion_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPv_Produktion_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPv_Produktion_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryPv_ZielpfadArgs = {
+  filter?: InputMaybe<Pv_Zielpfad_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPv_Zielpfad_AggregatedArgs = {
+  filter?: InputMaybe<Pv_Zielpfad_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryPv_Zielpfad_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPv_Zielpfad_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryQuiz_AnswersArgs = {
+  filter?: InputMaybe<Quiz_Answers_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryQuiz_Answers_AggregatedArgs = {
+  filter?: InputMaybe<Quiz_Answers_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryQuiz_Answers_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryQuiz_Answers_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryQuiz_QuestionsArgs = {
+  filter?: InputMaybe<Quiz_Questions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryQuiz_Questions_AggregatedArgs = {
+  filter?: InputMaybe<Quiz_Questions_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryQuiz_Questions_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryQuiz_Questions_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryQuotesArgs = {
+  filter?: InputMaybe<Quotes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryQuotes_AggregatedArgs = {
+  filter?: InputMaybe<Quotes_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryQuotes_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryQuotes_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryRegionsArgs = {
+  filter?: InputMaybe<Regions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryRegions_AggregatedArgs = {
+  filter?: InputMaybe<Regions_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryRegions_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryRegions_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryRenewable_Share_15minArgs = {
+  filter?: InputMaybe<Renewable_Share_15min_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryRenewable_Share_15min_AggregatedArgs = {
+  filter?: InputMaybe<Renewable_Share_15min_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryRenewable_Share_15min_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryRenewable_Share_15min_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryRenewable_Share_DailyArgs = {
+  filter?: InputMaybe<Renewable_Share_Daily_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryRenewable_Share_Daily_AggregatedArgs = {
+  filter?: InputMaybe<Renewable_Share_Daily_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryRenewable_Share_Daily_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryRenewable_Share_Daily_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QuerySeoArgs = {
+  filter?: InputMaybe<Seo_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySeo_AggregatedArgs = {
+  filter?: InputMaybe<Seo_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySeo_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QuerySeo_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QuerySitesArgs = {
+  filter?: InputMaybe<Sites_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySites_AggregatedArgs = {
+  filter?: InputMaybe<Sites_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySites_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QuerySites_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QuerySites_TranslationsArgs = {
+  filter?: InputMaybe<Sites_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySites_Translations_AggregatedArgs = {
+  filter?: InputMaybe<Sites_Translations_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuerySites_Translations_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QuerySites_Translations_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryStakeholdersArgs = {
+  filter?: InputMaybe<Stakeholders_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryStakeholders_AggregatedArgs = {
+  filter?: InputMaybe<Stakeholders_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryStakeholders_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryStakeholders_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryWasserkraft_ProduktionArgs = {
+  filter?: InputMaybe<Wasserkraft_Produktion_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWasserkraft_Produktion_AggregatedArgs = {
+  filter?: InputMaybe<Wasserkraft_Produktion_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWasserkraft_Produktion_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryWasserkraft_Produktion_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryWasserkraft_ZielpfadArgs = {
+  filter?: InputMaybe<Wasserkraft_Zielpfad_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWasserkraft_Zielpfad_AggregatedArgs = {
+  filter?: InputMaybe<Wasserkraft_Zielpfad_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWasserkraft_Zielpfad_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryWasserkraft_Zielpfad_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryWindkraft_ProduktionArgs = {
+  filter?: InputMaybe<Windkraft_Produktion_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWindkraft_Produktion_AggregatedArgs = {
+  filter?: InputMaybe<Windkraft_Produktion_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWindkraft_Produktion_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryWindkraft_Produktion_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+
+export type QueryWindkraft_ZielpfadArgs = {
+  filter?: InputMaybe<Windkraft_Zielpfad_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWindkraft_Zielpfad_AggregatedArgs = {
+  filter?: InputMaybe<Windkraft_Zielpfad_Filter>;
+  groupBy?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryWindkraft_Zielpfad_By_IdArgs = {
+  id: Scalars['ID']['input'];
+  version?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryWindkraft_Zielpfad_By_VersionArgs = {
+  id: Scalars['ID']['input'];
+  version: Scalars['String']['input'];
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  at_geosphere_data_mutated?: Maybe<At_Geosphere_Data_Mutated>;
+  at_geosphere_stations_mutated?: Maybe<At_Geosphere_Stations_Mutated>;
+  biomasse_produktion_mutated?: Maybe<Biomasse_Produktion_Mutated>;
+  biomasse_zielpfad_mutated?: Maybe<Biomasse_Zielpfad_Mutated>;
+  block_chart_charts_mutated?: Maybe<Block_Chart_Charts_Mutated>;
+  block_chart_mutated?: Maybe<Block_Chart_Mutated>;
+  block_donation_mutated?: Maybe<Block_Donation_Mutated>;
+  block_donation_translations_mutated?: Maybe<Block_Donation_Translations_Mutated>;
+  block_gallery_files_mutated?: Maybe<Block_Gallery_Files_Mutated>;
+  block_gallery_mutated?: Maybe<Block_Gallery_Mutated>;
+  block_grid_blocks_mutated?: Maybe<Block_Grid_Blocks_Mutated>;
+  block_grid_mutated?: Maybe<Block_Grid_Mutated>;
+  block_items_mutated?: Maybe<Block_Items_Mutated>;
+  block_items_translations_mutated?: Maybe<Block_Items_Translations_Mutated>;
+  block_news_mutated?: Maybe<Block_News_Mutated>;
+  block_panel_mutated?: Maybe<Block_Panel_Mutated>;
+  block_panel_translations_mutated?: Maybe<Block_Panel_Translations_Mutated>;
+  block_quiz_mutated?: Maybe<Block_Quiz_Mutated>;
+  block_quotes_mutated?: Maybe<Block_Quotes_Mutated>;
+  block_richtext_mutated?: Maybe<Block_Richtext_Mutated>;
+  block_richtext_translations_mutated?: Maybe<Block_Richtext_Translations_Mutated>;
+  block_teaser_mutated?: Maybe<Block_Teaser_Mutated>;
+  block_teaser_translations_mutated?: Maybe<Block_Teaser_Translations_Mutated>;
+  block_toggle_mutated?: Maybe<Block_Toggle_Mutated>;
+  block_toggle_translations_mutated?: Maybe<Block_Toggle_Translations_Mutated>;
+  carbon_prices_mutated?: Maybe<Carbon_Prices_Mutated>;
+  charts_mutated?: Maybe<Charts_Mutated>;
+  charts_translations_mutated?: Maybe<Charts_Translations_Mutated>;
+  companies_companies_sectors_mutated?: Maybe<Companies_Companies_Sectors_Mutated>;
+  companies_emissions_mutated?: Maybe<Companies_Emissions_Mutated>;
+  companies_mutated?: Maybe<Companies_Mutated>;
+  companies_sectors_mutated?: Maybe<Companies_Sectors_Mutated>;
+  countries_mutated?: Maybe<Countries_Mutated>;
+  datasets_mutated?: Maybe<Datasets_Mutated>;
+  de_dwd_data_mutated?: Maybe<De_Dwd_Data_Mutated>;
+  de_dwd_stations_mutated?: Maybe<De_Dwd_Stations_Mutated>;
+  directus_files_mutated?: Maybe<Directus_Files_Mutated>;
+  directus_presets_mutated?: Maybe<Directus_Presets_Mutated>;
+  directus_translations_mutated?: Maybe<Directus_Translations_Mutated>;
+  directus_users_mutated?: Maybe<Directus_Users_Mutated>;
+  ee_goals_mutated?: Maybe<Ee_Goals_Mutated>;
+  ee_historisch_mutated?: Maybe<Ee_Historisch_Mutated>;
+  ee_potentiale_mutated?: Maybe<Ee_Potentiale_Mutated>;
+  ee_produktion_mutated?: Maybe<Ee_Produktion_Mutated>;
+  ee_zielpfad_mutated?: Maybe<Ee_Zielpfad_Mutated>;
+  emissions_mutated?: Maybe<Emissions_Mutated>;
+  energy_mutated?: Maybe<Energy_Mutated>;
+  energy_renewable_share_mutated?: Maybe<Energy_Renewable_Share_Mutated>;
+  erneuerbare_2030_scenarios_mutated?: Maybe<Erneuerbare_2030_Scenarios_Mutated>;
+  gas_imports_mutated?: Maybe<Gas_Imports_Mutated>;
+  global_co2_concentration_mutated?: Maybe<Global_Co2_Concentration_Mutated>;
+  glossary_mutated?: Maybe<Glossary_Mutated>;
+  glossary_translations_mutated?: Maybe<Glossary_Translations_Mutated>;
+  languages_mutated?: Maybe<Languages_Mutated>;
+  mobility_cars_mutated?: Maybe<Mobility_Cars_Mutated>;
+  mobility_mutated?: Maybe<Mobility_Mutated>;
+  news_mutated?: Maybe<News_Mutated>;
+  news_translations_mutated?: Maybe<News_Translations_Mutated>;
+  pages_blocks_mutated?: Maybe<Pages_Blocks_Mutated>;
+  pages_mutated?: Maybe<Pages_Mutated>;
+  pages_translations_blocks_mutated?: Maybe<Pages_Translations_Blocks_Mutated>;
+  pages_translations_mutated?: Maybe<Pages_Translations_Mutated>;
+  policies_attributes_mutated?: Maybe<Policies_Attributes_Mutated>;
+  policies_attributes_translations_mutated?: Maybe<Policies_Attributes_Translations_Mutated>;
+  policies_mutated?: Maybe<Policies_Mutated>;
+  policies_policies_attributes_mutated?: Maybe<Policies_Policies_Attributes_Mutated>;
+  policies_stakeholders_mutated?: Maybe<Policies_Stakeholders_Mutated>;
+  policies_status_mutated?: Maybe<Policies_Status_Mutated>;
+  policies_status_translations_mutated?: Maybe<Policies_Status_Translations_Mutated>;
+  policies_translations_mutated?: Maybe<Policies_Translations_Mutated>;
+  policies_updates_mutated?: Maybe<Policies_Updates_Mutated>;
+  policies_updates_translations_mutated?: Maybe<Policies_Updates_Translations_Mutated>;
+  pv_produktion_mutated?: Maybe<Pv_Produktion_Mutated>;
+  pv_zielpfad_mutated?: Maybe<Pv_Zielpfad_Mutated>;
+  quiz_answers_mutated?: Maybe<Quiz_Answers_Mutated>;
+  quiz_questions_mutated?: Maybe<Quiz_Questions_Mutated>;
+  quotes_mutated?: Maybe<Quotes_Mutated>;
+  regions_mutated?: Maybe<Regions_Mutated>;
+  renewable_share_15min_mutated?: Maybe<Renewable_Share_15min_Mutated>;
+  renewable_share_daily_mutated?: Maybe<Renewable_Share_Daily_Mutated>;
+  seo_mutated?: Maybe<Seo_Mutated>;
+  sites_mutated?: Maybe<Sites_Mutated>;
+  sites_translations_mutated?: Maybe<Sites_Translations_Mutated>;
+  stakeholders_mutated?: Maybe<Stakeholders_Mutated>;
+  wasserkraft_produktion_mutated?: Maybe<Wasserkraft_Produktion_Mutated>;
+  wasserkraft_zielpfad_mutated?: Maybe<Wasserkraft_Zielpfad_Mutated>;
+  windkraft_produktion_mutated?: Maybe<Windkraft_Produktion_Mutated>;
+  windkraft_zielpfad_mutated?: Maybe<Windkraft_Zielpfad_Mutated>;
+};
+
+
+export type SubscriptionAt_Geosphere_Data_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionAt_Geosphere_Stations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBiomasse_Produktion_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBiomasse_Zielpfad_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Chart_Charts_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Chart_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Donation_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Donation_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Gallery_Files_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Gallery_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Grid_Blocks_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Grid_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Items_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Items_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_News_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Panel_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Panel_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Quiz_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Quotes_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Richtext_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Richtext_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Teaser_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Teaser_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Toggle_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionBlock_Toggle_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCarbon_Prices_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCharts_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCharts_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCompanies_Companies_Sectors_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCompanies_Emissions_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCompanies_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCompanies_Sectors_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionCountries_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDatasets_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDe_Dwd_Data_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDe_Dwd_Stations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDirectus_Files_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDirectus_Presets_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDirectus_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionDirectus_Users_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEe_Goals_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEe_Historisch_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEe_Potentiale_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEe_Produktion_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEe_Zielpfad_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEmissions_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEnergy_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionEnergy_Renewable_Share_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionErneuerbare_2030_Scenarios_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionGas_Imports_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionGlobal_Co2_Concentration_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionGlossary_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionGlossary_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionLanguages_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionMobility_Cars_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionMobility_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionNews_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionNews_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPages_Blocks_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPages_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPages_Translations_Blocks_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPages_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Attributes_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Attributes_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Policies_Attributes_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Stakeholders_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Status_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Status_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Updates_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPolicies_Updates_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPv_Produktion_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionPv_Zielpfad_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionQuiz_Answers_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionQuiz_Questions_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionQuotes_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionRegions_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionRenewable_Share_15min_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionRenewable_Share_Daily_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionSeo_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionSites_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionSites_Translations_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionStakeholders_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionWasserkraft_Produktion_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionWasserkraft_Zielpfad_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionWindkraft_Produktion_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+
+export type SubscriptionWindkraft_Zielpfad_MutatedArgs = {
+  event?: InputMaybe<EventEnum>;
+};
+
+export type At_Geosphere_Data = {
+  __typename?: 'at_geosphere_data';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  sh?: Maybe<Scalars['Float']['output']>;
+  station?: Maybe<At_Geosphere_Stations>;
+  tl_mittel?: Maybe<Scalars['Float']['output']>;
+  tlmax?: Maybe<Scalars['Float']['output']>;
+  tlmin?: Maybe<Scalars['Float']['output']>;
+};
+
+
+export type At_Geosphere_DataStationArgs = {
+  filter?: InputMaybe<At_Geosphere_Stations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type At_Geosphere_Data_Aggregated = {
+  __typename?: 'at_geosphere_data_aggregated';
+  avg?: Maybe<At_Geosphere_Data_Aggregated_Fields>;
+  avgDistinct?: Maybe<At_Geosphere_Data_Aggregated_Fields>;
+  count?: Maybe<At_Geosphere_Data_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<At_Geosphere_Data_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<At_Geosphere_Data_Aggregated_Fields>;
+  min?: Maybe<At_Geosphere_Data_Aggregated_Fields>;
+  sum?: Maybe<At_Geosphere_Data_Aggregated_Fields>;
+  sumDistinct?: Maybe<At_Geosphere_Data_Aggregated_Fields>;
+};
+
+export type At_Geosphere_Data_Aggregated_Count = {
+  __typename?: 'at_geosphere_data_aggregated_count';
+  date?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  sh?: Maybe<Scalars['Int']['output']>;
+  station?: Maybe<Scalars['Int']['output']>;
+  tl_mittel?: Maybe<Scalars['Int']['output']>;
+  tlmax?: Maybe<Scalars['Int']['output']>;
+  tlmin?: Maybe<Scalars['Int']['output']>;
+};
+
+export type At_Geosphere_Data_Aggregated_Fields = {
+  __typename?: 'at_geosphere_data_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  sh?: Maybe<Scalars['Float']['output']>;
+  tl_mittel?: Maybe<Scalars['Float']['output']>;
+  tlmax?: Maybe<Scalars['Float']['output']>;
+  tlmin?: Maybe<Scalars['Float']['output']>;
+};
+
+export type At_Geosphere_Data_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<At_Geosphere_Data_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<At_Geosphere_Data_Filter>>>;
+  date?: InputMaybe<Date_Filter_Operators>;
+  date_func?: InputMaybe<Date_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  sh?: InputMaybe<Number_Filter_Operators>;
+  station?: InputMaybe<At_Geosphere_Stations_Filter>;
+  tl_mittel?: InputMaybe<Number_Filter_Operators>;
+  tlmax?: InputMaybe<Number_Filter_Operators>;
+  tlmin?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type At_Geosphere_Data_Mutated = {
+  __typename?: 'at_geosphere_data_mutated';
+  data?: Maybe<At_Geosphere_Data>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type At_Geosphere_Stations = {
+  __typename?: 'at_geosphere_stations';
+  height?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  snow_coverage?: Maybe<Scalars['Float']['output']>;
+  start?: Maybe<Scalars['Date']['output']>;
+  start_func?: Maybe<Date_Functions>;
+  state?: Maybe<Scalars['String']['output']>;
+  station?: Maybe<Scalars['String']['output']>;
+};
+
+export type At_Geosphere_Stations_Aggregated = {
+  __typename?: 'at_geosphere_stations_aggregated';
+  avg?: Maybe<At_Geosphere_Stations_Aggregated_Fields>;
+  avgDistinct?: Maybe<At_Geosphere_Stations_Aggregated_Fields>;
+  count?: Maybe<At_Geosphere_Stations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<At_Geosphere_Stations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<At_Geosphere_Stations_Aggregated_Fields>;
+  min?: Maybe<At_Geosphere_Stations_Aggregated_Fields>;
+  sum?: Maybe<At_Geosphere_Stations_Aggregated_Fields>;
+  sumDistinct?: Maybe<At_Geosphere_Stations_Aggregated_Fields>;
+};
+
+export type At_Geosphere_Stations_Aggregated_Count = {
+  __typename?: 'at_geosphere_stations_aggregated_count';
+  height?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  latitude?: Maybe<Scalars['Int']['output']>;
+  longitude?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+  snow_coverage?: Maybe<Scalars['Int']['output']>;
+  start?: Maybe<Scalars['Int']['output']>;
+  state?: Maybe<Scalars['Int']['output']>;
+  station?: Maybe<Scalars['Int']['output']>;
+};
+
+export type At_Geosphere_Stations_Aggregated_Fields = {
+  __typename?: 'at_geosphere_stations_aggregated_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  snow_coverage?: Maybe<Scalars['Float']['output']>;
+};
+
+export type At_Geosphere_Stations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<At_Geosphere_Stations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<At_Geosphere_Stations_Filter>>>;
+  height?: InputMaybe<Number_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  latitude?: InputMaybe<Number_Filter_Operators>;
+  longitude?: InputMaybe<Number_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+  snow_coverage?: InputMaybe<Number_Filter_Operators>;
+  start?: InputMaybe<Date_Filter_Operators>;
+  start_func?: InputMaybe<Date_Function_Filter_Operators>;
+  state?: InputMaybe<String_Filter_Operators>;
+  station?: InputMaybe<String_Filter_Operators>;
+};
+
+export type At_Geosphere_Stations_Mutated = {
+  __typename?: 'at_geosphere_stations_mutated';
+  data?: Maybe<At_Geosphere_Stations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Big_Int_Filter_Operators = {
+  _between?: InputMaybe<Array<InputMaybe<Scalars['GraphQLBigInt']['input']>>>;
+  _eq?: InputMaybe<Scalars['GraphQLBigInt']['input']>;
+  _gt?: InputMaybe<Scalars['GraphQLBigInt']['input']>;
+  _gte?: InputMaybe<Scalars['GraphQLBigInt']['input']>;
+  _in?: InputMaybe<Array<InputMaybe<Scalars['GraphQLBigInt']['input']>>>;
+  _lt?: InputMaybe<Scalars['GraphQLBigInt']['input']>;
+  _lte?: InputMaybe<Scalars['GraphQLBigInt']['input']>;
+  _nbetween?: InputMaybe<Array<InputMaybe<Scalars['GraphQLBigInt']['input']>>>;
+  _neq?: InputMaybe<Scalars['GraphQLBigInt']['input']>;
+  _nin?: InputMaybe<Array<InputMaybe<Scalars['GraphQLBigInt']['input']>>>;
+  _nnull?: InputMaybe<Scalars['Boolean']['input']>;
+  _null?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type Biomasse_Produktion = {
+  __typename?: 'biomasse_produktion';
+  Biomasse?: Maybe<Scalars['Float']['output']>;
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Biomasse_ProduktionCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Biomasse_Produktion_Aggregated = {
+  __typename?: 'biomasse_produktion_aggregated';
+  avg?: Maybe<Biomasse_Produktion_Aggregated_Fields>;
+  avgDistinct?: Maybe<Biomasse_Produktion_Aggregated_Fields>;
+  count?: Maybe<Biomasse_Produktion_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Biomasse_Produktion_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Biomasse_Produktion_Aggregated_Fields>;
+  min?: Maybe<Biomasse_Produktion_Aggregated_Fields>;
+  sum?: Maybe<Biomasse_Produktion_Aggregated_Fields>;
+  sumDistinct?: Maybe<Biomasse_Produktion_Aggregated_Fields>;
+};
+
+export type Biomasse_Produktion_Aggregated_Count = {
+  __typename?: 'biomasse_produktion_aggregated_count';
+  Biomasse?: Maybe<Scalars['Int']['output']>;
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Biomasse_Produktion_Aggregated_Fields = {
+  __typename?: 'biomasse_produktion_aggregated_fields';
+  Biomasse?: Maybe<Scalars['Float']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Biomasse_Produktion_Filter = {
+  Biomasse?: InputMaybe<Number_Filter_Operators>;
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Date_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Biomasse_Produktion_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Biomasse_Produktion_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Biomasse_Produktion_Mutated = {
+  __typename?: 'biomasse_produktion_mutated';
+  data?: Maybe<Biomasse_Produktion>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Biomasse_Zielpfad = {
+  __typename?: 'biomasse_zielpfad';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Biomasse_ZielpfadCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Biomasse_Zielpfad_Aggregated = {
+  __typename?: 'biomasse_zielpfad_aggregated';
+  avg?: Maybe<Biomasse_Zielpfad_Aggregated_Fields>;
+  avgDistinct?: Maybe<Biomasse_Zielpfad_Aggregated_Fields>;
+  count?: Maybe<Biomasse_Zielpfad_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Biomasse_Zielpfad_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Biomasse_Zielpfad_Aggregated_Fields>;
+  min?: Maybe<Biomasse_Zielpfad_Aggregated_Fields>;
+  sum?: Maybe<Biomasse_Zielpfad_Aggregated_Fields>;
+  sumDistinct?: Maybe<Biomasse_Zielpfad_Aggregated_Fields>;
+};
+
+export type Biomasse_Zielpfad_Aggregated_Count = {
+  __typename?: 'biomasse_zielpfad_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Biomasse_Zielpfad_Aggregated_Fields = {
+  __typename?: 'biomasse_zielpfad_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Biomasse_Zielpfad_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Date_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Biomasse_Zielpfad_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Biomasse_Zielpfad_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Biomasse_Zielpfad_Mutated = {
+  __typename?: 'biomasse_zielpfad_mutated';
+  data?: Maybe<Biomasse_Zielpfad>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Chart = {
+  __typename?: 'block_chart';
+  charts?: Maybe<Array<Maybe<Block_Chart_Charts>>>;
+  charts_func?: Maybe<Count_Functions>;
+  hidewrapper?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Block_ChartChartsArgs = {
+  filter?: InputMaybe<Block_Chart_Charts_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Chart_Aggregated = {
+  __typename?: 'block_chart_aggregated';
+  count?: Maybe<Block_Chart_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Chart_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Chart_Aggregated_Count = {
+  __typename?: 'block_chart_aggregated_count';
+  charts?: Maybe<Scalars['Int']['output']>;
+  hidewrapper?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Chart_Charts = {
+  __typename?: 'block_chart_charts';
+  block?: Maybe<Block_Chart>;
+  chart?: Maybe<Charts>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Block_Chart_ChartsBlockArgs = {
+  filter?: InputMaybe<Block_Chart_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Chart_ChartsChartArgs = {
+  filter?: InputMaybe<Charts_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Chart_Charts_Aggregated = {
+  __typename?: 'block_chart_charts_aggregated';
+  avg?: Maybe<Block_Chart_Charts_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Chart_Charts_Aggregated_Fields>;
+  count?: Maybe<Block_Chart_Charts_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Chart_Charts_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Chart_Charts_Aggregated_Fields>;
+  min?: Maybe<Block_Chart_Charts_Aggregated_Fields>;
+  sum?: Maybe<Block_Chart_Charts_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Chart_Charts_Aggregated_Fields>;
+};
+
+export type Block_Chart_Charts_Aggregated_Count = {
+  __typename?: 'block_chart_charts_aggregated_count';
+  block?: Maybe<Scalars['Int']['output']>;
+  chart?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Chart_Charts_Aggregated_Fields = {
+  __typename?: 'block_chart_charts_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Chart_Charts_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Chart_Charts_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Chart_Charts_Filter>>>;
+  block?: InputMaybe<Block_Chart_Filter>;
+  chart?: InputMaybe<Charts_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Block_Chart_Charts_Mutated = {
+  __typename?: 'block_chart_charts_mutated';
+  data?: Maybe<Block_Chart_Charts>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Chart_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Chart_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Chart_Filter>>>;
+  charts?: InputMaybe<Block_Chart_Charts_Filter>;
+  charts_func?: InputMaybe<Count_Function_Filter_Operators>;
+  hidewrapper?: InputMaybe<Boolean_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Chart_Mutated = {
+  __typename?: 'block_chart_mutated';
+  data?: Maybe<Block_Chart>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Donation = {
+  __typename?: 'block_donation';
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Array<Maybe<Block_Donation_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type Block_DonationTranslationsArgs = {
+  filter?: InputMaybe<Block_Donation_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Donation_Aggregated = {
+  __typename?: 'block_donation_aggregated';
+  count?: Maybe<Block_Donation_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Donation_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Donation_Aggregated_Count = {
+  __typename?: 'block_donation_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Donation_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Donation_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Donation_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Block_Donation_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Block_Donation_Mutated = {
+  __typename?: 'block_donation_mutated';
+  data?: Maybe<Block_Donation>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Donation_Translations = {
+  __typename?: 'block_donation_translations';
+  block_donation_id?: Maybe<Block_Donation>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  links?: Maybe<Scalars['JSON']['output']>;
+  links_func?: Maybe<Count_Functions>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_Donation_TranslationsBlock_Donation_IdArgs = {
+  filter?: InputMaybe<Block_Donation_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Donation_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Donation_Translations_Aggregated = {
+  __typename?: 'block_donation_translations_aggregated';
+  avg?: Maybe<Block_Donation_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Donation_Translations_Aggregated_Fields>;
+  count?: Maybe<Block_Donation_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Donation_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Donation_Translations_Aggregated_Fields>;
+  min?: Maybe<Block_Donation_Translations_Aggregated_Fields>;
+  sum?: Maybe<Block_Donation_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Donation_Translations_Aggregated_Fields>;
+};
+
+export type Block_Donation_Translations_Aggregated_Count = {
+  __typename?: 'block_donation_translations_aggregated_count';
+  block_donation_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  links?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Donation_Translations_Aggregated_Fields = {
+  __typename?: 'block_donation_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Donation_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Donation_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Donation_Translations_Filter>>>;
+  block_donation_id?: InputMaybe<Block_Donation_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  links?: InputMaybe<String_Filter_Operators>;
+  links_func?: InputMaybe<Count_Function_Filter_Operators>;
+  text?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Donation_Translations_Mutated = {
+  __typename?: 'block_donation_translations_mutated';
+  data?: Maybe<Block_Donation_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Gallery = {
+  __typename?: 'block_gallery';
+  files?: Maybe<Array<Maybe<Block_Gallery_Files>>>;
+  files_func?: Maybe<Count_Functions>;
+  id: Scalars['ID']['output'];
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_GalleryFilesArgs = {
+  filter?: InputMaybe<Block_Gallery_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Gallery_Aggregated = {
+  __typename?: 'block_gallery_aggregated';
+  count?: Maybe<Block_Gallery_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Gallery_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Gallery_Aggregated_Count = {
+  __typename?: 'block_gallery_aggregated_count';
+  files?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Gallery_Files = {
+  __typename?: 'block_gallery_files';
+  block_gallery_id?: Maybe<Block_Gallery>;
+  directus_files_id?: Maybe<Directus_Files>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Block_Gallery_FilesBlock_Gallery_IdArgs = {
+  filter?: InputMaybe<Block_Gallery_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Gallery_FilesDirectus_Files_IdArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Gallery_Files_Aggregated = {
+  __typename?: 'block_gallery_files_aggregated';
+  avg?: Maybe<Block_Gallery_Files_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Gallery_Files_Aggregated_Fields>;
+  count?: Maybe<Block_Gallery_Files_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Gallery_Files_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Gallery_Files_Aggregated_Fields>;
+  min?: Maybe<Block_Gallery_Files_Aggregated_Fields>;
+  sum?: Maybe<Block_Gallery_Files_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Gallery_Files_Aggregated_Fields>;
+};
+
+export type Block_Gallery_Files_Aggregated_Count = {
+  __typename?: 'block_gallery_files_aggregated_count';
+  block_gallery_id?: Maybe<Scalars['Int']['output']>;
+  directus_files_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Gallery_Files_Aggregated_Fields = {
+  __typename?: 'block_gallery_files_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Gallery_Files_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Gallery_Files_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Gallery_Files_Filter>>>;
+  block_gallery_id?: InputMaybe<Block_Gallery_Filter>;
+  directus_files_id?: InputMaybe<Directus_Files_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Block_Gallery_Files_Mutated = {
+  __typename?: 'block_gallery_files_mutated';
+  data?: Maybe<Block_Gallery_Files>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Gallery_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Gallery_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Gallery_Filter>>>;
+  files?: InputMaybe<Block_Gallery_Files_Filter>;
+  files_func?: InputMaybe<Count_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Gallery_Mutated = {
+  __typename?: 'block_gallery_mutated';
+  data?: Maybe<Block_Gallery>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Grid = {
+  __typename?: 'block_grid';
+  blocks?: Maybe<Array<Maybe<Block_Grid_Blocks>>>;
+  blocks_func?: Maybe<Count_Functions>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Block_GridBlocksArgs = {
+  filter?: InputMaybe<Block_Grid_Blocks_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Grid_Aggregated = {
+  __typename?: 'block_grid_aggregated';
+  count?: Maybe<Block_Grid_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Grid_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Grid_Aggregated_Count = {
+  __typename?: 'block_grid_aggregated_count';
+  blocks?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Grid_Blocks = {
+  __typename?: 'block_grid_blocks';
+  block_grid_id?: Maybe<Block_Grid>;
+  collection?: Maybe<Scalars['String']['output']>;
+  height?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  item?: Maybe<Block_Grid_Blocks_Item_Union>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  width?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_Grid_BlocksBlock_Grid_IdArgs = {
+  filter?: InputMaybe<Block_Grid_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Grid_Blocks_Aggregated = {
+  __typename?: 'block_grid_blocks_aggregated';
+  avg?: Maybe<Block_Grid_Blocks_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Grid_Blocks_Aggregated_Fields>;
+  count?: Maybe<Block_Grid_Blocks_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Grid_Blocks_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Grid_Blocks_Aggregated_Fields>;
+  min?: Maybe<Block_Grid_Blocks_Aggregated_Fields>;
+  sum?: Maybe<Block_Grid_Blocks_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Grid_Blocks_Aggregated_Fields>;
+};
+
+export type Block_Grid_Blocks_Aggregated_Count = {
+  __typename?: 'block_grid_blocks_aggregated_count';
+  block_grid_id?: Maybe<Scalars['Int']['output']>;
+  collection?: Maybe<Scalars['Int']['output']>;
+  height?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  item?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Grid_Blocks_Aggregated_Fields = {
+  __typename?: 'block_grid_blocks_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Grid_Blocks_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Grid_Blocks_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Grid_Blocks_Filter>>>;
+  block_grid_id?: InputMaybe<Block_Grid_Filter>;
+  collection?: InputMaybe<String_Filter_Operators>;
+  height?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  item__block_chart?: InputMaybe<Block_Chart_Filter>;
+  item__block_donation?: InputMaybe<Block_Donation_Filter>;
+  item__block_news?: InputMaybe<Block_News_Filter>;
+  item__block_panel?: InputMaybe<Block_Panel_Filter>;
+  item__block_quiz?: InputMaybe<Block_Quiz_Filter>;
+  item__block_richtext?: InputMaybe<Block_Richtext_Filter>;
+  item__block_teaser?: InputMaybe<Block_Teaser_Filter>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+  width?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Grid_Blocks_Item_Union = Block_Chart | Block_Donation | Block_News | Block_Panel | Block_Quiz | Block_Richtext | Block_Teaser;
+
+export type Block_Grid_Blocks_Mutated = {
+  __typename?: 'block_grid_blocks_mutated';
+  data?: Maybe<Block_Grid_Blocks>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Grid_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Grid_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Grid_Filter>>>;
+  blocks?: InputMaybe<Block_Grid_Blocks_Filter>;
+  blocks_func?: InputMaybe<Count_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Grid_Mutated = {
+  __typename?: 'block_grid_mutated';
+  data?: Maybe<Block_Grid>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Items = {
+  __typename?: 'block_items';
+  id: Scalars['ID']['output'];
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  translations?: Maybe<Array<Maybe<Block_Items_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  types?: Maybe<Scalars['JSON']['output']>;
+  types_func?: Maybe<Count_Functions>;
+};
+
+
+export type Block_ItemsTranslationsArgs = {
+  filter?: InputMaybe<Block_Items_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Items_Aggregated = {
+  __typename?: 'block_items_aggregated';
+  count?: Maybe<Block_Items_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Items_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Items_Aggregated_Count = {
+  __typename?: 'block_items_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  types?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Items_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Items_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Items_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+  tags?: InputMaybe<String_Filter_Operators>;
+  tags_func?: InputMaybe<Count_Function_Filter_Operators>;
+  translations?: InputMaybe<Block_Items_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  types?: InputMaybe<String_Filter_Operators>;
+  types_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Block_Items_Mutated = {
+  __typename?: 'block_items_mutated';
+  data?: Maybe<Block_Items>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Items_Translations = {
+  __typename?: 'block_items_translations';
+  block_items_id?: Maybe<Block_Items>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_Items_TranslationsBlock_Items_IdArgs = {
+  filter?: InputMaybe<Block_Items_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Items_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Items_Translations_Aggregated = {
+  __typename?: 'block_items_translations_aggregated';
+  avg?: Maybe<Block_Items_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Items_Translations_Aggregated_Fields>;
+  count?: Maybe<Block_Items_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Items_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Items_Translations_Aggregated_Fields>;
+  min?: Maybe<Block_Items_Translations_Aggregated_Fields>;
+  sum?: Maybe<Block_Items_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Items_Translations_Aggregated_Fields>;
+};
+
+export type Block_Items_Translations_Aggregated_Count = {
+  __typename?: 'block_items_translations_aggregated_count';
+  block_items_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Items_Translations_Aggregated_Fields = {
+  __typename?: 'block_items_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Items_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Items_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Items_Translations_Filter>>>;
+  block_items_id?: InputMaybe<Block_Items_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Items_Translations_Mutated = {
+  __typename?: 'block_items_translations_mutated';
+  data?: Maybe<Block_Items_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_News = {
+  __typename?: 'block_news';
+  id: Scalars['ID']['output'];
+};
+
+export type Block_News_Aggregated = {
+  __typename?: 'block_news_aggregated';
+  avg?: Maybe<Block_News_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_News_Aggregated_Fields>;
+  count?: Maybe<Block_News_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_News_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_News_Aggregated_Fields>;
+  min?: Maybe<Block_News_Aggregated_Fields>;
+  sum?: Maybe<Block_News_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_News_Aggregated_Fields>;
+};
+
+export type Block_News_Aggregated_Count = {
+  __typename?: 'block_news_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_News_Aggregated_Fields = {
+  __typename?: 'block_news_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_News_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_News_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_News_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Block_News_Mutated = {
+  __typename?: 'block_news_mutated';
+  data?: Maybe<Block_News>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Panel = {
+  __typename?: 'block_panel';
+  chart?: Maybe<Charts>;
+  chart_custom?: Maybe<Scalars['String']['output']>;
+  colorBackground?: Maybe<Scalars['String']['output']>;
+  colorText?: Maybe<Scalars['String']['output']>;
+  icon?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  number?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Array<Maybe<Block_Panel_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  unit?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_PanelChartArgs = {
+  filter?: InputMaybe<Charts_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_PanelTranslationsArgs = {
+  filter?: InputMaybe<Block_Panel_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Panel_Aggregated = {
+  __typename?: 'block_panel_aggregated';
+  avg?: Maybe<Block_Panel_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Panel_Aggregated_Fields>;
+  count?: Maybe<Block_Panel_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Panel_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Panel_Aggregated_Fields>;
+  min?: Maybe<Block_Panel_Aggregated_Fields>;
+  sum?: Maybe<Block_Panel_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Panel_Aggregated_Fields>;
+};
+
+export type Block_Panel_Aggregated_Count = {
+  __typename?: 'block_panel_aggregated_count';
+  chart?: Maybe<Scalars['Int']['output']>;
+  chart_custom?: Maybe<Scalars['Int']['output']>;
+  colorBackground?: Maybe<Scalars['Int']['output']>;
+  colorText?: Maybe<Scalars['Int']['output']>;
+  icon?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  number?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Panel_Aggregated_Fields = {
+  __typename?: 'block_panel_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Panel_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Panel_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Panel_Filter>>>;
+  chart?: InputMaybe<Charts_Filter>;
+  chart_custom?: InputMaybe<String_Filter_Operators>;
+  colorBackground?: InputMaybe<String_Filter_Operators>;
+  colorText?: InputMaybe<String_Filter_Operators>;
+  icon?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  number?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Block_Panel_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Panel_Mutated = {
+  __typename?: 'block_panel_mutated';
+  data?: Maybe<Block_Panel>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Panel_Translations = {
+  __typename?: 'block_panel_translations';
+  block_panel_id?: Maybe<Block_Panel>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  link?: Maybe<Scalars['String']['output']>;
+  list?: Maybe<Scalars['JSON']['output']>;
+  list_func?: Maybe<Count_Functions>;
+  source?: Maybe<Scalars['String']['output']>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_Panel_TranslationsBlock_Panel_IdArgs = {
+  filter?: InputMaybe<Block_Panel_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Panel_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Panel_Translations_Aggregated = {
+  __typename?: 'block_panel_translations_aggregated';
+  avg?: Maybe<Block_Panel_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Panel_Translations_Aggregated_Fields>;
+  count?: Maybe<Block_Panel_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Panel_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Panel_Translations_Aggregated_Fields>;
+  min?: Maybe<Block_Panel_Translations_Aggregated_Fields>;
+  sum?: Maybe<Block_Panel_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Panel_Translations_Aggregated_Fields>;
+};
+
+export type Block_Panel_Translations_Aggregated_Count = {
+  __typename?: 'block_panel_translations_aggregated_count';
+  block_panel_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  link?: Maybe<Scalars['Int']['output']>;
+  list?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  subtitle?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Panel_Translations_Aggregated_Fields = {
+  __typename?: 'block_panel_translations_aggregated_fields';
+  block_panel_id?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Panel_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Panel_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Panel_Translations_Filter>>>;
+  block_panel_id?: InputMaybe<Block_Panel_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  link?: InputMaybe<String_Filter_Operators>;
+  list?: InputMaybe<String_Filter_Operators>;
+  list_func?: InputMaybe<Count_Function_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  subtitle?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Panel_Translations_Mutated = {
+  __typename?: 'block_panel_translations_mutated';
+  data?: Maybe<Block_Panel_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Quiz = {
+  __typename?: 'block_quiz';
+  id: Scalars['ID']['output'];
+};
+
+export type Block_Quiz_Aggregated = {
+  __typename?: 'block_quiz_aggregated';
+  count?: Maybe<Block_Quiz_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Quiz_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Quiz_Aggregated_Count = {
+  __typename?: 'block_quiz_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Quiz_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Quiz_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Quiz_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Quiz_Mutated = {
+  __typename?: 'block_quiz_mutated';
+  data?: Maybe<Block_Quiz>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Quotes = {
+  __typename?: 'block_quotes';
+  id: Scalars['ID']['output'];
+};
+
+export type Block_Quotes_Aggregated = {
+  __typename?: 'block_quotes_aggregated';
+  count?: Maybe<Block_Quotes_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Quotes_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Quotes_Aggregated_Count = {
+  __typename?: 'block_quotes_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Quotes_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Quotes_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Quotes_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Quotes_Mutated = {
+  __typename?: 'block_quotes_mutated';
+  data?: Maybe<Block_Quotes>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Richtext = {
+  __typename?: 'block_richtext';
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Array<Maybe<Block_Richtext_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type Block_RichtextTranslationsArgs = {
+  filter?: InputMaybe<Block_Richtext_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Richtext_Aggregated = {
+  __typename?: 'block_richtext_aggregated';
+  count?: Maybe<Block_Richtext_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Richtext_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Richtext_Aggregated_Count = {
+  __typename?: 'block_richtext_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Richtext_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Richtext_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Richtext_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Block_Richtext_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Block_Richtext_Mutated = {
+  __typename?: 'block_richtext_mutated';
+  data?: Maybe<Block_Richtext>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Richtext_Translations = {
+  __typename?: 'block_richtext_translations';
+  block_richtext_id?: Maybe<Block_Richtext>;
+  content?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+};
+
+
+export type Block_Richtext_TranslationsBlock_Richtext_IdArgs = {
+  filter?: InputMaybe<Block_Richtext_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Richtext_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Richtext_Translations_Aggregated = {
+  __typename?: 'block_richtext_translations_aggregated';
+  avg?: Maybe<Block_Richtext_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Richtext_Translations_Aggregated_Fields>;
+  count?: Maybe<Block_Richtext_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Richtext_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Richtext_Translations_Aggregated_Fields>;
+  min?: Maybe<Block_Richtext_Translations_Aggregated_Fields>;
+  sum?: Maybe<Block_Richtext_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Richtext_Translations_Aggregated_Fields>;
+};
+
+export type Block_Richtext_Translations_Aggregated_Count = {
+  __typename?: 'block_richtext_translations_aggregated_count';
+  block_richtext_id?: Maybe<Scalars['Int']['output']>;
+  content?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Richtext_Translations_Aggregated_Fields = {
+  __typename?: 'block_richtext_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Richtext_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Richtext_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Richtext_Translations_Filter>>>;
+  block_richtext_id?: InputMaybe<Block_Richtext_Filter>;
+  content?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+};
+
+export type Block_Richtext_Translations_Mutated = {
+  __typename?: 'block_richtext_translations_mutated';
+  data?: Maybe<Block_Richtext_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Teaser = {
+  __typename?: 'block_teaser';
+  id: Scalars['ID']['output'];
+  image?: Maybe<Directus_Files>;
+  translations?: Maybe<Array<Maybe<Block_Teaser_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type Block_TeaserImageArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_TeaserTranslationsArgs = {
+  filter?: InputMaybe<Block_Teaser_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Teaser_Aggregated = {
+  __typename?: 'block_teaser_aggregated';
+  count?: Maybe<Block_Teaser_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Teaser_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Teaser_Aggregated_Count = {
+  __typename?: 'block_teaser_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  image?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Teaser_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Teaser_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Teaser_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+  image?: InputMaybe<Directus_Files_Filter>;
+  translations?: InputMaybe<Block_Teaser_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Block_Teaser_Mutated = {
+  __typename?: 'block_teaser_mutated';
+  data?: Maybe<Block_Teaser>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Teaser_Translations = {
+  __typename?: 'block_teaser_translations';
+  block_teaser_id?: Maybe<Block_Teaser>;
+  description?: Maybe<Scalars['String']['output']>;
+  eyebrow?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  link?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_Teaser_TranslationsBlock_Teaser_IdArgs = {
+  filter?: InputMaybe<Block_Teaser_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Teaser_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Teaser_Translations_Aggregated = {
+  __typename?: 'block_teaser_translations_aggregated';
+  avg?: Maybe<Block_Teaser_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Teaser_Translations_Aggregated_Fields>;
+  count?: Maybe<Block_Teaser_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Teaser_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Teaser_Translations_Aggregated_Fields>;
+  min?: Maybe<Block_Teaser_Translations_Aggregated_Fields>;
+  sum?: Maybe<Block_Teaser_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Teaser_Translations_Aggregated_Fields>;
+};
+
+export type Block_Teaser_Translations_Aggregated_Count = {
+  __typename?: 'block_teaser_translations_aggregated_count';
+  block_teaser_id?: Maybe<Scalars['Int']['output']>;
+  description?: Maybe<Scalars['Int']['output']>;
+  eyebrow?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  link?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Teaser_Translations_Aggregated_Fields = {
+  __typename?: 'block_teaser_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Teaser_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Teaser_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Teaser_Translations_Filter>>>;
+  block_teaser_id?: InputMaybe<Block_Teaser_Filter>;
+  description?: InputMaybe<String_Filter_Operators>;
+  eyebrow?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  link?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Teaser_Translations_Mutated = {
+  __typename?: 'block_teaser_translations_mutated';
+  data?: Maybe<Block_Teaser_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Toggle = {
+  __typename?: 'block_toggle';
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Array<Maybe<Block_Toggle_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type Block_ToggleTranslationsArgs = {
+  filter?: InputMaybe<Block_Toggle_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Toggle_Aggregated = {
+  __typename?: 'block_toggle_aggregated';
+  count?: Maybe<Block_Toggle_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Toggle_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Block_Toggle_Aggregated_Count = {
+  __typename?: 'block_toggle_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Toggle_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Toggle_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Toggle_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Block_Toggle_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Block_Toggle_Mutated = {
+  __typename?: 'block_toggle_mutated';
+  data?: Maybe<Block_Toggle>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Block_Toggle_Translations = {
+  __typename?: 'block_toggle_translations';
+  answer?: Maybe<Scalars['String']['output']>;
+  block_toggle_id?: Maybe<Block_Toggle>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  question?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Block_Toggle_TranslationsBlock_Toggle_IdArgs = {
+  filter?: InputMaybe<Block_Toggle_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Block_Toggle_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Block_Toggle_Translations_Aggregated = {
+  __typename?: 'block_toggle_translations_aggregated';
+  avg?: Maybe<Block_Toggle_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Block_Toggle_Translations_Aggregated_Fields>;
+  count?: Maybe<Block_Toggle_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Block_Toggle_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Block_Toggle_Translations_Aggregated_Fields>;
+  min?: Maybe<Block_Toggle_Translations_Aggregated_Fields>;
+  sum?: Maybe<Block_Toggle_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Block_Toggle_Translations_Aggregated_Fields>;
+};
+
+export type Block_Toggle_Translations_Aggregated_Count = {
+  __typename?: 'block_toggle_translations_aggregated_count';
+  answer?: Maybe<Scalars['Int']['output']>;
+  block_toggle_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  question?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Block_Toggle_Translations_Aggregated_Fields = {
+  __typename?: 'block_toggle_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Block_Toggle_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Block_Toggle_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Block_Toggle_Translations_Filter>>>;
+  answer?: InputMaybe<String_Filter_Operators>;
+  block_toggle_id?: InputMaybe<Block_Toggle_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  question?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Block_Toggle_Translations_Mutated = {
+  __typename?: 'block_toggle_translations_mutated';
+  data?: Maybe<Block_Toggle_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Boolean_Filter_Operators = {
+  _eq?: InputMaybe<Scalars['Boolean']['input']>;
+  _neq?: InputMaybe<Scalars['Boolean']['input']>;
+  _nnull?: InputMaybe<Scalars['Boolean']['input']>;
+  _null?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type Carbon_Prices = {
+  __typename?: 'carbon_prices';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  region?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Carbon_Prices_Aggregated = {
+  __typename?: 'carbon_prices_aggregated';
+  avg?: Maybe<Carbon_Prices_Aggregated_Fields>;
+  avgDistinct?: Maybe<Carbon_Prices_Aggregated_Fields>;
+  count?: Maybe<Carbon_Prices_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Carbon_Prices_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Carbon_Prices_Aggregated_Fields>;
+  min?: Maybe<Carbon_Prices_Aggregated_Fields>;
+  sum?: Maybe<Carbon_Prices_Aggregated_Fields>;
+  sumDistinct?: Maybe<Carbon_Prices_Aggregated_Fields>;
+};
+
+export type Carbon_Prices_Aggregated_Count = {
+  __typename?: 'carbon_prices_aggregated_count';
+  date?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Carbon_Prices_Aggregated_Fields = {
+  __typename?: 'carbon_prices_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Carbon_Prices_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Carbon_Prices_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Carbon_Prices_Filter>>>;
+  date?: InputMaybe<Date_Filter_Operators>;
+  date_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  region?: InputMaybe<String_Filter_Operators>;
+  type?: InputMaybe<String_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Carbon_Prices_Mutated = {
+  __typename?: 'carbon_prices_mutated';
+  data?: Maybe<Carbon_Prices>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Charts = {
+  __typename?: 'charts';
+  custom_sveltestring?: Maybe<Scalars['String']['output']>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  id_old?: Maybe<Scalars['String']['output']>;
+  layers?: Maybe<Scalars['JSON']['output']>;
+  layers_func?: Maybe<Count_Functions>;
+  options?: Maybe<Scalars['JSON']['output']>;
+  options_func?: Maybe<Count_Functions>;
+  site?: Maybe<Sites>;
+  status?: Maybe<Scalars['String']['output']>;
+  table_name?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Array<Maybe<Charts_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  type?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+  x_axis?: Maybe<Scalars['String']['output']>;
+  x_axis_name?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type ChartsSiteArgs = {
+  filter?: InputMaybe<Sites_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ChartsTranslationsArgs = {
+  filter?: InputMaybe<Charts_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ChartsUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ChartsUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Charts_Aggregated = {
+  __typename?: 'charts_aggregated';
+  count?: Maybe<Charts_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Charts_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Charts_Aggregated_Count = {
+  __typename?: 'charts_aggregated_count';
+  custom_sveltestring?: Maybe<Scalars['Int']['output']>;
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  id_old?: Maybe<Scalars['Int']['output']>;
+  layers?: Maybe<Scalars['Int']['output']>;
+  options?: Maybe<Scalars['Int']['output']>;
+  site?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  table_name?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+  x_axis?: Maybe<Scalars['Int']['output']>;
+  x_axis_name?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Charts_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Charts_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Charts_Filter>>>;
+  custom_sveltestring?: InputMaybe<String_Filter_Operators>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  id_old?: InputMaybe<String_Filter_Operators>;
+  layers?: InputMaybe<String_Filter_Operators>;
+  layers_func?: InputMaybe<Count_Function_Filter_Operators>;
+  options?: InputMaybe<String_Filter_Operators>;
+  options_func?: InputMaybe<Count_Function_Filter_Operators>;
+  site?: InputMaybe<Sites_Filter>;
+  status?: InputMaybe<String_Filter_Operators>;
+  table_name?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Charts_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  type?: InputMaybe<String_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+  x_axis?: InputMaybe<String_Filter_Operators>;
+  x_axis_name?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Charts_Mutated = {
+  __typename?: 'charts_mutated';
+  data?: Maybe<Charts>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Charts_Translations = {
+  __typename?: 'charts_translations';
+  charts_id?: Maybe<Charts>;
+  heading?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  methods?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  variables?: Maybe<Scalars['JSON']['output']>;
+  variables_func?: Maybe<Count_Functions>;
+};
+
+
+export type Charts_TranslationsCharts_IdArgs = {
+  filter?: InputMaybe<Charts_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Charts_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Charts_Translations_Aggregated = {
+  __typename?: 'charts_translations_aggregated';
+  avg?: Maybe<Charts_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Charts_Translations_Aggregated_Fields>;
+  count?: Maybe<Charts_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Charts_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Charts_Translations_Aggregated_Fields>;
+  min?: Maybe<Charts_Translations_Aggregated_Fields>;
+  sum?: Maybe<Charts_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Charts_Translations_Aggregated_Fields>;
+};
+
+export type Charts_Translations_Aggregated_Count = {
+  __typename?: 'charts_translations_aggregated_count';
+  charts_id?: Maybe<Scalars['Int']['output']>;
+  heading?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  methods?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+  variables?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Charts_Translations_Aggregated_Fields = {
+  __typename?: 'charts_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Charts_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Charts_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Charts_Translations_Filter>>>;
+  charts_id?: InputMaybe<Charts_Filter>;
+  heading?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  methods?: InputMaybe<String_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  tags?: InputMaybe<String_Filter_Operators>;
+  tags_func?: InputMaybe<Count_Function_Filter_Operators>;
+  text?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+  variables?: InputMaybe<String_Filter_Operators>;
+  variables_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Charts_Translations_Mutated = {
+  __typename?: 'charts_translations_mutated';
+  data?: Maybe<Charts_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Companies = {
+  __typename?: 'companies';
+  climate_neutrality_goal?: Maybe<Scalars['String']['output']>;
+  climate_neutrality_scopes?: Maybe<Scalars['JSON']['output']>;
+  climate_neutrality_scopes_func?: Maybe<Count_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  intermediate_goal?: Maybe<Scalars['Boolean']['output']>;
+  logo?: Maybe<Directus_Files>;
+  member_sbt?: Maybe<Scalars['Boolean']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  sectors?: Maybe<Array<Maybe<Companies_Companies_Sectors>>>;
+  sectors_func?: Maybe<Count_Functions>;
+  status?: Maybe<Scalars['String']['output']>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type CompaniesLogoArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type CompaniesSectorsArgs = {
+  filter?: InputMaybe<Companies_Companies_Sectors_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type CompaniesUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Companies_Aggregated = {
+  __typename?: 'companies_aggregated';
+  count?: Maybe<Companies_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Companies_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Companies_Aggregated_Count = {
+  __typename?: 'companies_aggregated_count';
+  climate_neutrality_goal?: Maybe<Scalars['Int']['output']>;
+  climate_neutrality_scopes?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  intermediate_goal?: Maybe<Scalars['Int']['output']>;
+  logo?: Maybe<Scalars['Int']['output']>;
+  member_sbt?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+  sectors?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Companies_Companies_Sectors = {
+  __typename?: 'companies_companies_sectors';
+  companies_id?: Maybe<Companies>;
+  companies_sectors_id?: Maybe<Companies_Sectors>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Companies_Companies_SectorsCompanies_IdArgs = {
+  filter?: InputMaybe<Companies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Companies_Companies_SectorsCompanies_Sectors_IdArgs = {
+  filter?: InputMaybe<Companies_Sectors_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Companies_Companies_Sectors_Aggregated = {
+  __typename?: 'companies_companies_sectors_aggregated';
+  avg?: Maybe<Companies_Companies_Sectors_Aggregated_Fields>;
+  avgDistinct?: Maybe<Companies_Companies_Sectors_Aggregated_Fields>;
+  count?: Maybe<Companies_Companies_Sectors_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Companies_Companies_Sectors_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Companies_Companies_Sectors_Aggregated_Fields>;
+  min?: Maybe<Companies_Companies_Sectors_Aggregated_Fields>;
+  sum?: Maybe<Companies_Companies_Sectors_Aggregated_Fields>;
+  sumDistinct?: Maybe<Companies_Companies_Sectors_Aggregated_Fields>;
+};
+
+export type Companies_Companies_Sectors_Aggregated_Count = {
+  __typename?: 'companies_companies_sectors_aggregated_count';
+  companies_id?: Maybe<Scalars['Int']['output']>;
+  companies_sectors_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Companies_Companies_Sectors_Aggregated_Fields = {
+  __typename?: 'companies_companies_sectors_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Companies_Companies_Sectors_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Companies_Companies_Sectors_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Companies_Companies_Sectors_Filter>>>;
+  companies_id?: InputMaybe<Companies_Filter>;
+  companies_sectors_id?: InputMaybe<Companies_Sectors_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Companies_Companies_Sectors_Mutated = {
+  __typename?: 'companies_companies_sectors_mutated';
+  data?: Maybe<Companies_Companies_Sectors>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Companies_Emissions = {
+  __typename?: 'companies_emissions';
+  category?: Maybe<Scalars['String']['output']>;
+  company?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  notes?: Maybe<Scalars['String']['output']>;
+  scope?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  source_link?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['GraphQLBigInt']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Companies_Emissions_Aggregated = {
+  __typename?: 'companies_emissions_aggregated';
+  avg?: Maybe<Companies_Emissions_Aggregated_Fields>;
+  avgDistinct?: Maybe<Companies_Emissions_Aggregated_Fields>;
+  count?: Maybe<Companies_Emissions_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Companies_Emissions_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Companies_Emissions_Aggregated_Fields>;
+  min?: Maybe<Companies_Emissions_Aggregated_Fields>;
+  sum?: Maybe<Companies_Emissions_Aggregated_Fields>;
+  sumDistinct?: Maybe<Companies_Emissions_Aggregated_Fields>;
+};
+
+export type Companies_Emissions_Aggregated_Count = {
+  __typename?: 'companies_emissions_aggregated_count';
+  category?: Maybe<Scalars['Int']['output']>;
+  company?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  notes?: Maybe<Scalars['Int']['output']>;
+  scope?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  source_link?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Companies_Emissions_Aggregated_Fields = {
+  __typename?: 'companies_emissions_aggregated_fields';
+  scope?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Companies_Emissions_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Companies_Emissions_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Companies_Emissions_Filter>>>;
+  category?: InputMaybe<String_Filter_Operators>;
+  company?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  notes?: InputMaybe<String_Filter_Operators>;
+  scope?: InputMaybe<Number_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  source_link?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Big_Int_Filter_Operators>;
+  year?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Companies_Emissions_Mutated = {
+  __typename?: 'companies_emissions_mutated';
+  data?: Maybe<Companies_Emissions>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Companies_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Companies_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Companies_Filter>>>;
+  climate_neutrality_goal?: InputMaybe<String_Filter_Operators>;
+  climate_neutrality_scopes?: InputMaybe<String_Filter_Operators>;
+  climate_neutrality_scopes_func?: InputMaybe<Count_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  intermediate_goal?: InputMaybe<Boolean_Filter_Operators>;
+  logo?: InputMaybe<Directus_Files_Filter>;
+  member_sbt?: InputMaybe<Boolean_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+  sectors?: InputMaybe<Companies_Companies_Sectors_Filter>;
+  sectors_func?: InputMaybe<Count_Function_Filter_Operators>;
+  status?: InputMaybe<String_Filter_Operators>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Companies_Mutated = {
+  __typename?: 'companies_mutated';
+  data?: Maybe<Companies>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Companies_Sectors = {
+  __typename?: 'companies_sectors';
+  icon?: Maybe<Directus_Files>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Companies_SectorsIconArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Companies_Sectors_Aggregated = {
+  __typename?: 'companies_sectors_aggregated';
+  count?: Maybe<Companies_Sectors_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Companies_Sectors_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Companies_Sectors_Aggregated_Count = {
+  __typename?: 'companies_sectors_aggregated_count';
+  icon?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Companies_Sectors_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Companies_Sectors_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Companies_Sectors_Filter>>>;
+  icon?: InputMaybe<Directus_Files_Filter>;
+  id?: InputMaybe<String_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Companies_Sectors_Mutated = {
+  __typename?: 'companies_sectors_mutated';
+  data?: Maybe<Companies_Sectors>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Count_Function_Filter_Operators = {
+  count?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Count_Functions = {
+  __typename?: 'count_functions';
+  count?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Countries = {
+  __typename?: 'countries';
+  area?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['String']['output']>;
+  longitude?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  name_de?: Maybe<Scalars['String']['output']>;
+  population?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Countries_Aggregated = {
+  __typename?: 'countries_aggregated';
+  avg?: Maybe<Countries_Aggregated_Fields>;
+  avgDistinct?: Maybe<Countries_Aggregated_Fields>;
+  count?: Maybe<Countries_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Countries_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Countries_Aggregated_Fields>;
+  min?: Maybe<Countries_Aggregated_Fields>;
+  sum?: Maybe<Countries_Aggregated_Fields>;
+  sumDistinct?: Maybe<Countries_Aggregated_Fields>;
+};
+
+export type Countries_Aggregated_Count = {
+  __typename?: 'countries_aggregated_count';
+  area?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  latitude?: Maybe<Scalars['Int']['output']>;
+  longitude?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+  name_de?: Maybe<Scalars['Int']['output']>;
+  population?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Countries_Aggregated_Fields = {
+  __typename?: 'countries_aggregated_fields';
+  area?: Maybe<Scalars['Float']['output']>;
+  population?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Countries_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Countries_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Countries_Filter>>>;
+  area?: InputMaybe<Number_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  latitude?: InputMaybe<String_Filter_Operators>;
+  longitude?: InputMaybe<String_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+  name_de?: InputMaybe<String_Filter_Operators>;
+  population?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Countries_Mutated = {
+  __typename?: 'countries_mutated';
+  data?: Maybe<Countries>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Datasets = {
+  __typename?: 'datasets';
+  id: Scalars['ID']['output'];
+};
+
+export type Datasets_Aggregated = {
+  __typename?: 'datasets_aggregated';
+  avg?: Maybe<Datasets_Aggregated_Fields>;
+  avgDistinct?: Maybe<Datasets_Aggregated_Fields>;
+  count?: Maybe<Datasets_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Datasets_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Datasets_Aggregated_Fields>;
+  min?: Maybe<Datasets_Aggregated_Fields>;
+  sum?: Maybe<Datasets_Aggregated_Fields>;
+  sumDistinct?: Maybe<Datasets_Aggregated_Fields>;
+};
+
+export type Datasets_Aggregated_Count = {
+  __typename?: 'datasets_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Datasets_Aggregated_Fields = {
+  __typename?: 'datasets_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Datasets_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Datasets_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Datasets_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Datasets_Mutated = {
+  __typename?: 'datasets_mutated';
+  data?: Maybe<Datasets>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Date_Filter_Operators = {
+  _between?: InputMaybe<Array<InputMaybe<Scalars['GraphQLStringOrFloat']['input']>>>;
+  _eq?: InputMaybe<Scalars['String']['input']>;
+  _gt?: InputMaybe<Scalars['String']['input']>;
+  _gte?: InputMaybe<Scalars['String']['input']>;
+  _in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  _lt?: InputMaybe<Scalars['String']['input']>;
+  _lte?: InputMaybe<Scalars['String']['input']>;
+  _nbetween?: InputMaybe<Array<InputMaybe<Scalars['GraphQLStringOrFloat']['input']>>>;
+  _neq?: InputMaybe<Scalars['String']['input']>;
+  _nin?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  _nnull?: InputMaybe<Scalars['Boolean']['input']>;
+  _null?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type Date_Function_Filter_Operators = {
+  day?: InputMaybe<Number_Filter_Operators>;
+  month?: InputMaybe<Number_Filter_Operators>;
+  week?: InputMaybe<Number_Filter_Operators>;
+  weekday?: InputMaybe<Number_Filter_Operators>;
+  year?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Date_Functions = {
+  __typename?: 'date_functions';
+  day?: Maybe<Scalars['Int']['output']>;
+  month?: Maybe<Scalars['Int']['output']>;
+  week?: Maybe<Scalars['Int']['output']>;
+  weekday?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Datetime_Function_Filter_Operators = {
+  day?: InputMaybe<Number_Filter_Operators>;
+  hour?: InputMaybe<Number_Filter_Operators>;
+  minute?: InputMaybe<Number_Filter_Operators>;
+  month?: InputMaybe<Number_Filter_Operators>;
+  second?: InputMaybe<Number_Filter_Operators>;
+  week?: InputMaybe<Number_Filter_Operators>;
+  weekday?: InputMaybe<Number_Filter_Operators>;
+  year?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Datetime_Functions = {
+  __typename?: 'datetime_functions';
+  day?: Maybe<Scalars['Int']['output']>;
+  hour?: Maybe<Scalars['Int']['output']>;
+  minute?: Maybe<Scalars['Int']['output']>;
+  month?: Maybe<Scalars['Int']['output']>;
+  second?: Maybe<Scalars['Int']['output']>;
+  week?: Maybe<Scalars['Int']['output']>;
+  weekday?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type De_Dwd_Data = {
+  __typename?: 'de_dwd_data';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  sh?: Maybe<Scalars['Float']['output']>;
+  station?: Maybe<De_Dwd_Stations>;
+  tl_mittel?: Maybe<Scalars['Float']['output']>;
+  tlmax?: Maybe<Scalars['Float']['output']>;
+  tlmin?: Maybe<Scalars['Float']['output']>;
+};
+
+
+export type De_Dwd_DataStationArgs = {
+  filter?: InputMaybe<De_Dwd_Stations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type De_Dwd_Data_Aggregated = {
+  __typename?: 'de_dwd_data_aggregated';
+  avg?: Maybe<De_Dwd_Data_Aggregated_Fields>;
+  avgDistinct?: Maybe<De_Dwd_Data_Aggregated_Fields>;
+  count?: Maybe<De_Dwd_Data_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<De_Dwd_Data_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<De_Dwd_Data_Aggregated_Fields>;
+  min?: Maybe<De_Dwd_Data_Aggregated_Fields>;
+  sum?: Maybe<De_Dwd_Data_Aggregated_Fields>;
+  sumDistinct?: Maybe<De_Dwd_Data_Aggregated_Fields>;
+};
+
+export type De_Dwd_Data_Aggregated_Count = {
+  __typename?: 'de_dwd_data_aggregated_count';
+  date?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  sh?: Maybe<Scalars['Int']['output']>;
+  station?: Maybe<Scalars['Int']['output']>;
+  tl_mittel?: Maybe<Scalars['Int']['output']>;
+  tlmax?: Maybe<Scalars['Int']['output']>;
+  tlmin?: Maybe<Scalars['Int']['output']>;
+};
+
+export type De_Dwd_Data_Aggregated_Fields = {
+  __typename?: 'de_dwd_data_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  sh?: Maybe<Scalars['Float']['output']>;
+  tl_mittel?: Maybe<Scalars['Float']['output']>;
+  tlmax?: Maybe<Scalars['Float']['output']>;
+  tlmin?: Maybe<Scalars['Float']['output']>;
+};
+
+export type De_Dwd_Data_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<De_Dwd_Data_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<De_Dwd_Data_Filter>>>;
+  date?: InputMaybe<Date_Filter_Operators>;
+  date_func?: InputMaybe<Date_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  sh?: InputMaybe<Number_Filter_Operators>;
+  station?: InputMaybe<De_Dwd_Stations_Filter>;
+  tl_mittel?: InputMaybe<Number_Filter_Operators>;
+  tlmax?: InputMaybe<Number_Filter_Operators>;
+  tlmin?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type De_Dwd_Data_Mutated = {
+  __typename?: 'de_dwd_data_mutated';
+  data?: Maybe<De_Dwd_Data>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type De_Dwd_Stations = {
+  __typename?: 'de_dwd_stations';
+  date_start?: Maybe<Scalars['Date']['output']>;
+  date_start_func?: Maybe<Date_Functions>;
+  height?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  snow_coverage?: Maybe<Scalars['Float']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  station?: Maybe<Scalars['String']['output']>;
+};
+
+export type De_Dwd_Stations_Aggregated = {
+  __typename?: 'de_dwd_stations_aggregated';
+  avg?: Maybe<De_Dwd_Stations_Aggregated_Fields>;
+  avgDistinct?: Maybe<De_Dwd_Stations_Aggregated_Fields>;
+  count?: Maybe<De_Dwd_Stations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<De_Dwd_Stations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<De_Dwd_Stations_Aggregated_Fields>;
+  min?: Maybe<De_Dwd_Stations_Aggregated_Fields>;
+  sum?: Maybe<De_Dwd_Stations_Aggregated_Fields>;
+  sumDistinct?: Maybe<De_Dwd_Stations_Aggregated_Fields>;
+};
+
+export type De_Dwd_Stations_Aggregated_Count = {
+  __typename?: 'de_dwd_stations_aggregated_count';
+  date_start?: Maybe<Scalars['Int']['output']>;
+  height?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  latitude?: Maybe<Scalars['Int']['output']>;
+  longitude?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+  snow_coverage?: Maybe<Scalars['Int']['output']>;
+  state?: Maybe<Scalars['Int']['output']>;
+  station?: Maybe<Scalars['Int']['output']>;
+};
+
+export type De_Dwd_Stations_Aggregated_Fields = {
+  __typename?: 'de_dwd_stations_aggregated_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  snow_coverage?: Maybe<Scalars['Float']['output']>;
+};
+
+export type De_Dwd_Stations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<De_Dwd_Stations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<De_Dwd_Stations_Filter>>>;
+  date_start?: InputMaybe<Date_Filter_Operators>;
+  date_start_func?: InputMaybe<Date_Function_Filter_Operators>;
+  height?: InputMaybe<Number_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  latitude?: InputMaybe<Number_Filter_Operators>;
+  longitude?: InputMaybe<Number_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+  snow_coverage?: InputMaybe<Number_Filter_Operators>;
+  state?: InputMaybe<String_Filter_Operators>;
+  station?: InputMaybe<String_Filter_Operators>;
+};
+
+export type De_Dwd_Stations_Mutated = {
+  __typename?: 'de_dwd_stations_mutated';
+  data?: Maybe<De_Dwd_Stations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Directus_Files = {
+  __typename?: 'directus_files';
+  charset?: Maybe<Scalars['String']['output']>;
+  copyright?: Maybe<Scalars['String']['output']>;
+  created_on?: Maybe<Scalars['Date']['output']>;
+  created_on_func?: Maybe<Datetime_Functions>;
+  description?: Maybe<Scalars['String']['output']>;
+  duration?: Maybe<Scalars['Int']['output']>;
+  embed?: Maybe<Scalars['String']['output']>;
+  filename_disk?: Maybe<Scalars['String']['output']>;
+  filename_download: Scalars['String']['output'];
+  filesize?: Maybe<Scalars['GraphQLBigInt']['output']>;
+  focal_point_x?: Maybe<Scalars['Int']['output']>;
+  focal_point_y?: Maybe<Scalars['Int']['output']>;
+  folder?: Maybe<Scalars['String']['output']>;
+  height?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  link?: Maybe<Scalars['String']['output']>;
+  location?: Maybe<Scalars['String']['output']>;
+  metadata?: Maybe<Scalars['JSON']['output']>;
+  metadata_func?: Maybe<Count_Functions>;
+  modified_by?: Maybe<Directus_Users>;
+  modified_on?: Maybe<Scalars['Date']['output']>;
+  modified_on_func?: Maybe<Datetime_Functions>;
+  storage: Scalars['String']['output'];
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  title?: Maybe<Scalars['String']['output']>;
+  tus_data?: Maybe<Scalars['JSON']['output']>;
+  tus_data_func?: Maybe<Count_Functions>;
+  tus_id?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  uploaded_by?: Maybe<Directus_Users>;
+  uploaded_on?: Maybe<Scalars['Date']['output']>;
+  uploaded_on_func?: Maybe<Datetime_Functions>;
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Directus_FilesModified_ByArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Directus_FilesUploaded_ByArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Directus_Files_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Directus_Files_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Directus_Files_Filter>>>;
+  charset?: InputMaybe<String_Filter_Operators>;
+  copyright?: InputMaybe<String_Filter_Operators>;
+  created_on?: InputMaybe<Date_Filter_Operators>;
+  created_on_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  description?: InputMaybe<String_Filter_Operators>;
+  duration?: InputMaybe<Number_Filter_Operators>;
+  embed?: InputMaybe<String_Filter_Operators>;
+  filename_disk?: InputMaybe<String_Filter_Operators>;
+  filename_download?: InputMaybe<String_Filter_Operators>;
+  filesize?: InputMaybe<Big_Int_Filter_Operators>;
+  focal_point_x?: InputMaybe<Number_Filter_Operators>;
+  focal_point_y?: InputMaybe<Number_Filter_Operators>;
+  folder?: InputMaybe<String_Filter_Operators>;
+  height?: InputMaybe<Number_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  link?: InputMaybe<String_Filter_Operators>;
+  location?: InputMaybe<String_Filter_Operators>;
+  metadata?: InputMaybe<String_Filter_Operators>;
+  metadata_func?: InputMaybe<Count_Function_Filter_Operators>;
+  modified_by?: InputMaybe<Directus_Users_Filter>;
+  modified_on?: InputMaybe<Date_Filter_Operators>;
+  modified_on_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  storage?: InputMaybe<String_Filter_Operators>;
+  tags?: InputMaybe<String_Filter_Operators>;
+  tags_func?: InputMaybe<Count_Function_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+  tus_data?: InputMaybe<String_Filter_Operators>;
+  tus_data_func?: InputMaybe<Count_Function_Filter_Operators>;
+  tus_id?: InputMaybe<String_Filter_Operators>;
+  type?: InputMaybe<String_Filter_Operators>;
+  uploaded_by?: InputMaybe<Directus_Users_Filter>;
+  uploaded_on?: InputMaybe<Date_Filter_Operators>;
+  uploaded_on_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  width?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Directus_Files_Mutated = {
+  __typename?: 'directus_files_mutated';
+  data?: Maybe<Directus_Files>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Directus_Presets = {
+  __typename?: 'directus_presets';
+  bookmark?: Maybe<Scalars['String']['output']>;
+  collection?: Maybe<Scalars['String']['output']>;
+  color?: Maybe<Scalars['String']['output']>;
+  filter?: Maybe<Scalars['JSON']['output']>;
+  filter_func?: Maybe<Count_Functions>;
+  icon?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  layout?: Maybe<Scalars['String']['output']>;
+  layout_options?: Maybe<Scalars['JSON']['output']>;
+  layout_options_func?: Maybe<Count_Functions>;
+  layout_query?: Maybe<Scalars['JSON']['output']>;
+  layout_query_func?: Maybe<Count_Functions>;
+  refresh_interval?: Maybe<Scalars['Int']['output']>;
+  role?: Maybe<Scalars['String']['output']>;
+  search?: Maybe<Scalars['String']['output']>;
+  user?: Maybe<Directus_Users>;
+};
+
+
+export type Directus_PresetsUserArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Directus_Presets_Mutated = {
+  __typename?: 'directus_presets_mutated';
+  data?: Maybe<Directus_Presets>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Directus_Translations = {
+  __typename?: 'directus_translations';
+  id: Scalars['ID']['output'];
+  key: Scalars['String']['output'];
+  language: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
+export type Directus_Translations_Mutated = {
+  __typename?: 'directus_translations_mutated';
+  data?: Maybe<Directus_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Directus_Users = {
+  __typename?: 'directus_users';
+  avatar?: Maybe<Directus_Files>;
+  description?: Maybe<Scalars['String']['output']>;
+  first_name?: Maybe<Scalars['String']['output']>;
+  last_name?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Directus_UsersAvatarArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Directus_Users_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Directus_Users_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Directus_Users_Filter>>>;
+  avatar?: InputMaybe<Directus_Files_Filter>;
+  description?: InputMaybe<String_Filter_Operators>;
+  first_name?: InputMaybe<String_Filter_Operators>;
+  last_name?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Directus_Users_Mutated = {
+  __typename?: 'directus_users_mutated';
+  data?: Maybe<Directus_Users>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Ee_Goals = {
+  __typename?: 'ee_goals';
+  Country?: Maybe<Countries>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  current_production?: Maybe<Scalars['Float']['output']>;
+  goal_amount?: Maybe<Scalars['String']['output']>;
+  goal_year?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  last_update_check?: Maybe<Scalars['Date']['output']>;
+  last_update_check_func?: Maybe<Date_Functions>;
+  note?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Regions>;
+  source_label?: Maybe<Scalars['String']['output']>;
+  source_link?: Maybe<Scalars['String']['output']>;
+  source_year?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+};
+
+
+export type Ee_GoalsCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Ee_GoalsRegionArgs = {
+  filter?: InputMaybe<Regions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Ee_Goals_Aggregated = {
+  __typename?: 'ee_goals_aggregated';
+  avg?: Maybe<Ee_Goals_Aggregated_Fields>;
+  avgDistinct?: Maybe<Ee_Goals_Aggregated_Fields>;
+  count?: Maybe<Ee_Goals_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Ee_Goals_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Ee_Goals_Aggregated_Fields>;
+  min?: Maybe<Ee_Goals_Aggregated_Fields>;
+  sum?: Maybe<Ee_Goals_Aggregated_Fields>;
+  sumDistinct?: Maybe<Ee_Goals_Aggregated_Fields>;
+};
+
+export type Ee_Goals_Aggregated_Count = {
+  __typename?: 'ee_goals_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  Type?: Maybe<Scalars['Int']['output']>;
+  current_production?: Maybe<Scalars['Int']['output']>;
+  goal_amount?: Maybe<Scalars['Int']['output']>;
+  goal_year?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  last_update_check?: Maybe<Scalars['Int']['output']>;
+  note?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  source_label?: Maybe<Scalars['Int']['output']>;
+  source_link?: Maybe<Scalars['Int']['output']>;
+  source_year?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Ee_Goals_Aggregated_Fields = {
+  __typename?: 'ee_goals_aggregated_fields';
+  current_production?: Maybe<Scalars['Float']['output']>;
+  goal_year?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+  source_year?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Ee_Goals_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  Type?: InputMaybe<String_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Ee_Goals_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Ee_Goals_Filter>>>;
+  current_production?: InputMaybe<Number_Filter_Operators>;
+  goal_amount?: InputMaybe<String_Filter_Operators>;
+  goal_year?: InputMaybe<Number_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  last_update_check?: InputMaybe<Date_Filter_Operators>;
+  last_update_check_func?: InputMaybe<Date_Function_Filter_Operators>;
+  note?: InputMaybe<String_Filter_Operators>;
+  region?: InputMaybe<Regions_Filter>;
+  source_label?: InputMaybe<String_Filter_Operators>;
+  source_link?: InputMaybe<String_Filter_Operators>;
+  source_year?: InputMaybe<Number_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Ee_Goals_Mutated = {
+  __typename?: 'ee_goals_mutated';
+  data?: Maybe<Ee_Goals>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Ee_Historisch = {
+  __typename?: 'ee_historisch';
+  Country?: Maybe<Countries>;
+  id: Scalars['ID']['output'];
+  pv?: Maybe<Scalars['Float']['output']>;
+  region?: Maybe<Regions>;
+  wasserkraft?: Maybe<Scalars['Float']['output']>;
+  windkraft?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Ee_HistorischCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Ee_HistorischRegionArgs = {
+  filter?: InputMaybe<Regions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Ee_Historisch_Aggregated = {
+  __typename?: 'ee_historisch_aggregated';
+  avg?: Maybe<Ee_Historisch_Aggregated_Fields>;
+  avgDistinct?: Maybe<Ee_Historisch_Aggregated_Fields>;
+  count?: Maybe<Ee_Historisch_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Ee_Historisch_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Ee_Historisch_Aggregated_Fields>;
+  min?: Maybe<Ee_Historisch_Aggregated_Fields>;
+  sum?: Maybe<Ee_Historisch_Aggregated_Fields>;
+  sumDistinct?: Maybe<Ee_Historisch_Aggregated_Fields>;
+};
+
+export type Ee_Historisch_Aggregated_Count = {
+  __typename?: 'ee_historisch_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  pv?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  wasserkraft?: Maybe<Scalars['Int']['output']>;
+  windkraft?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Ee_Historisch_Aggregated_Fields = {
+  __typename?: 'ee_historisch_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  pv?: Maybe<Scalars['Float']['output']>;
+  wasserkraft?: Maybe<Scalars['Float']['output']>;
+  windkraft?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Ee_Historisch_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  _and?: InputMaybe<Array<InputMaybe<Ee_Historisch_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Ee_Historisch_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  pv?: InputMaybe<Number_Filter_Operators>;
+  region?: InputMaybe<Regions_Filter>;
+  wasserkraft?: InputMaybe<Number_Filter_Operators>;
+  windkraft?: InputMaybe<Number_Filter_Operators>;
+  year?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Ee_Historisch_Mutated = {
+  __typename?: 'ee_historisch_mutated';
+  data?: Maybe<Ee_Historisch>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Ee_Potentiale = {
+  __typename?: 'ee_potentiale';
+  Country?: Maybe<Countries>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  id: Scalars['ID']['output'];
+  link?: Maybe<Scalars['String']['output']>;
+  note?: Maybe<Scalars['String']['output']>;
+  potential_class?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  region?: Maybe<Regions>;
+  source?: Maybe<Scalars['String']['output']>;
+  value_TWh?: Maybe<Scalars['Float']['output']>;
+};
+
+
+export type Ee_PotentialeCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Ee_PotentialeRegionArgs = {
+  filter?: InputMaybe<Regions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Ee_Potentiale_Aggregated = {
+  __typename?: 'ee_potentiale_aggregated';
+  avg?: Maybe<Ee_Potentiale_Aggregated_Fields>;
+  avgDistinct?: Maybe<Ee_Potentiale_Aggregated_Fields>;
+  count?: Maybe<Ee_Potentiale_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Ee_Potentiale_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Ee_Potentiale_Aggregated_Fields>;
+  min?: Maybe<Ee_Potentiale_Aggregated_Fields>;
+  sum?: Maybe<Ee_Potentiale_Aggregated_Fields>;
+  sumDistinct?: Maybe<Ee_Potentiale_Aggregated_Fields>;
+};
+
+export type Ee_Potentiale_Aggregated_Count = {
+  __typename?: 'ee_potentiale_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  Type?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  link?: Maybe<Scalars['Int']['output']>;
+  note?: Maybe<Scalars['Int']['output']>;
+  potential_class?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  value_TWh?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Ee_Potentiale_Aggregated_Fields = {
+  __typename?: 'ee_potentiale_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value_TWh?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Ee_Potentiale_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  Type?: InputMaybe<String_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Ee_Potentiale_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Ee_Potentiale_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  link?: InputMaybe<String_Filter_Operators>;
+  note?: InputMaybe<String_Filter_Operators>;
+  potential_class?: InputMaybe<String_Filter_Operators>;
+  region?: InputMaybe<Regions_Filter>;
+  source?: InputMaybe<String_Filter_Operators>;
+  value_TWh?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Ee_Potentiale_Mutated = {
+  __typename?: 'ee_potentiale_mutated';
+  data?: Maybe<Ee_Potentiale>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Ee_Produktion = {
+  __typename?: 'ee_produktion';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  id: Scalars['ID']['output'];
+  unit?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+
+export type Ee_ProduktionCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Ee_Produktion_Aggregated = {
+  __typename?: 'ee_produktion_aggregated';
+  avg?: Maybe<Ee_Produktion_Aggregated_Fields>;
+  avgDistinct?: Maybe<Ee_Produktion_Aggregated_Fields>;
+  count?: Maybe<Ee_Produktion_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Ee_Produktion_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Ee_Produktion_Aggregated_Fields>;
+  min?: Maybe<Ee_Produktion_Aggregated_Fields>;
+  sum?: Maybe<Ee_Produktion_Aggregated_Fields>;
+  sumDistinct?: Maybe<Ee_Produktion_Aggregated_Fields>;
+};
+
+export type Ee_Produktion_Aggregated_Count = {
+  __typename?: 'ee_produktion_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  Type?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Ee_Produktion_Aggregated_Fields = {
+  __typename?: 'ee_produktion_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Ee_Produktion_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  Type?: InputMaybe<String_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Ee_Produktion_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Ee_Produktion_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Ee_Produktion_Mutated = {
+  __typename?: 'ee_produktion_mutated';
+  data?: Maybe<Ee_Produktion>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Ee_Zielpfad = {
+  __typename?: 'ee_zielpfad';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Ee_ZielpfadCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Ee_Zielpfad_Aggregated = {
+  __typename?: 'ee_zielpfad_aggregated';
+  avg?: Maybe<Ee_Zielpfad_Aggregated_Fields>;
+  avgDistinct?: Maybe<Ee_Zielpfad_Aggregated_Fields>;
+  count?: Maybe<Ee_Zielpfad_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Ee_Zielpfad_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Ee_Zielpfad_Aggregated_Fields>;
+  min?: Maybe<Ee_Zielpfad_Aggregated_Fields>;
+  sum?: Maybe<Ee_Zielpfad_Aggregated_Fields>;
+  sumDistinct?: Maybe<Ee_Zielpfad_Aggregated_Fields>;
+};
+
+export type Ee_Zielpfad_Aggregated_Count = {
+  __typename?: 'ee_zielpfad_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  Type?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Ee_Zielpfad_Aggregated_Fields = {
+  __typename?: 'ee_zielpfad_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Ee_Zielpfad_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  Type?: InputMaybe<String_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Ee_Zielpfad_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Ee_Zielpfad_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Ee_Zielpfad_Mutated = {
+  __typename?: 'ee_zielpfad_mutated';
+  data?: Maybe<Ee_Zielpfad>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Emissions = {
+  __typename?: 'emissions';
+  category?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  update?: Maybe<Scalars['Date']['output']>;
+  update_func?: Maybe<Datetime_Functions>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Emissions_Aggregated = {
+  __typename?: 'emissions_aggregated';
+  avg?: Maybe<Emissions_Aggregated_Fields>;
+  avgDistinct?: Maybe<Emissions_Aggregated_Fields>;
+  count?: Maybe<Emissions_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Emissions_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Emissions_Aggregated_Fields>;
+  min?: Maybe<Emissions_Aggregated_Fields>;
+  sum?: Maybe<Emissions_Aggregated_Fields>;
+  sumDistinct?: Maybe<Emissions_Aggregated_Fields>;
+};
+
+export type Emissions_Aggregated_Count = {
+  __typename?: 'emissions_aggregated_count';
+  category?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  note?: Maybe<Scalars['Int']['output']>;
+  period?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+  update?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Emissions_Aggregated_Fields = {
+  __typename?: 'emissions_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Emissions_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Emissions_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Emissions_Filter>>>;
+  category?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  note?: InputMaybe<String_Filter_Operators>;
+  period?: InputMaybe<String_Filter_Operators>;
+  region?: InputMaybe<String_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+  update?: InputMaybe<Date_Filter_Operators>;
+  update_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Emissions_Mutated = {
+  __typename?: 'emissions_mutated';
+  data?: Maybe<Emissions>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Energy = {
+  __typename?: 'energy';
+  category?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['String']['output']>;
+  period_x?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  update?: Maybe<Scalars['Date']['output']>;
+  update_func?: Maybe<Datetime_Functions>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Energy_Aggregated = {
+  __typename?: 'energy_aggregated';
+  avg?: Maybe<Energy_Aggregated_Fields>;
+  avgDistinct?: Maybe<Energy_Aggregated_Fields>;
+  count?: Maybe<Energy_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Energy_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Energy_Aggregated_Fields>;
+  min?: Maybe<Energy_Aggregated_Fields>;
+  sum?: Maybe<Energy_Aggregated_Fields>;
+  sumDistinct?: Maybe<Energy_Aggregated_Fields>;
+};
+
+export type Energy_Aggregated_Count = {
+  __typename?: 'energy_aggregated_count';
+  category?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  note?: Maybe<Scalars['Int']['output']>;
+  period?: Maybe<Scalars['Int']['output']>;
+  period_x?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+  update?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Energy_Aggregated_Fields = {
+  __typename?: 'energy_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Energy_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Energy_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Energy_Filter>>>;
+  category?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  note?: InputMaybe<String_Filter_Operators>;
+  period?: InputMaybe<String_Filter_Operators>;
+  period_x?: InputMaybe<String_Filter_Operators>;
+  region?: InputMaybe<String_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+  update?: InputMaybe<Date_Filter_Operators>;
+  update_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Energy_Mutated = {
+  __typename?: 'energy_mutated';
+  data?: Maybe<Energy>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Energy_Renewable_Share = {
+  __typename?: 'energy_renewable_share';
+  category?: Maybe<Scalars['String']['output']>;
+  country?: Maybe<Countries>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['Date']['output']>;
+  period_func?: Maybe<Datetime_Functions>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+
+export type Energy_Renewable_ShareCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Energy_Renewable_Share_Aggregated = {
+  __typename?: 'energy_renewable_share_aggregated';
+  avg?: Maybe<Energy_Renewable_Share_Aggregated_Fields>;
+  avgDistinct?: Maybe<Energy_Renewable_Share_Aggregated_Fields>;
+  count?: Maybe<Energy_Renewable_Share_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Energy_Renewable_Share_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Energy_Renewable_Share_Aggregated_Fields>;
+  min?: Maybe<Energy_Renewable_Share_Aggregated_Fields>;
+  sum?: Maybe<Energy_Renewable_Share_Aggregated_Fields>;
+  sumDistinct?: Maybe<Energy_Renewable_Share_Aggregated_Fields>;
+};
+
+export type Energy_Renewable_Share_Aggregated_Count = {
+  __typename?: 'energy_renewable_share_aggregated_count';
+  category?: Maybe<Scalars['Int']['output']>;
+  country?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  note?: Maybe<Scalars['Int']['output']>;
+  period?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Energy_Renewable_Share_Aggregated_Fields = {
+  __typename?: 'energy_renewable_share_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Energy_Renewable_Share_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Energy_Renewable_Share_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Energy_Renewable_Share_Filter>>>;
+  category?: InputMaybe<String_Filter_Operators>;
+  country?: InputMaybe<Countries_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  note?: InputMaybe<String_Filter_Operators>;
+  period?: InputMaybe<Date_Filter_Operators>;
+  period_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Energy_Renewable_Share_Mutated = {
+  __typename?: 'energy_renewable_share_mutated';
+  data?: Maybe<Energy_Renewable_Share>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Erneuerbare_2030_Scenarios = {
+  __typename?: 'erneuerbare_2030_scenarios';
+  Country?: Maybe<Countries>;
+  energy_type?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  release_date?: Maybe<Scalars['Date']['output']>;
+  release_date_func?: Maybe<Date_Functions>;
+  scenario?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Erneuerbare_2030_ScenariosCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Erneuerbare_2030_Scenarios_Aggregated = {
+  __typename?: 'erneuerbare_2030_scenarios_aggregated';
+  avg?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Fields>;
+  avgDistinct?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Fields>;
+  count?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Fields>;
+  min?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Fields>;
+  sum?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Fields>;
+  sumDistinct?: Maybe<Erneuerbare_2030_Scenarios_Aggregated_Fields>;
+};
+
+export type Erneuerbare_2030_Scenarios_Aggregated_Count = {
+  __typename?: 'erneuerbare_2030_scenarios_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  energy_type?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  release_date?: Maybe<Scalars['Int']['output']>;
+  scenario?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Erneuerbare_2030_Scenarios_Aggregated_Fields = {
+  __typename?: 'erneuerbare_2030_scenarios_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Erneuerbare_2030_Scenarios_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  _and?: InputMaybe<Array<InputMaybe<Erneuerbare_2030_Scenarios_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Erneuerbare_2030_Scenarios_Filter>>>;
+  energy_type?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  release_date?: InputMaybe<Date_Filter_Operators>;
+  release_date_func?: InputMaybe<Date_Function_Filter_Operators>;
+  scenario?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+  year?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Erneuerbare_2030_Scenarios_Mutated = {
+  __typename?: 'erneuerbare_2030_scenarios_mutated';
+  data?: Maybe<Erneuerbare_2030_Scenarios>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Gas_Imports = {
+  __typename?: 'gas_imports';
+  Country?: Maybe<Countries>;
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  import_country?: Maybe<Countries>;
+  /** alternative to "import_country". will be used if "import_country" is null. */
+  import_source?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Gas_ImportsCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Gas_ImportsImport_CountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Gas_Imports_Aggregated = {
+  __typename?: 'gas_imports_aggregated';
+  avg?: Maybe<Gas_Imports_Aggregated_Fields>;
+  avgDistinct?: Maybe<Gas_Imports_Aggregated_Fields>;
+  count?: Maybe<Gas_Imports_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Gas_Imports_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Gas_Imports_Aggregated_Fields>;
+  min?: Maybe<Gas_Imports_Aggregated_Fields>;
+  sum?: Maybe<Gas_Imports_Aggregated_Fields>;
+  sumDistinct?: Maybe<Gas_Imports_Aggregated_Fields>;
+};
+
+export type Gas_Imports_Aggregated_Count = {
+  __typename?: 'gas_imports_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  date?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  import_country?: Maybe<Scalars['Int']['output']>;
+  /** alternative to "import_country". will be used if "import_country" is null. */
+  import_source?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Gas_Imports_Aggregated_Fields = {
+  __typename?: 'gas_imports_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Gas_Imports_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  _and?: InputMaybe<Array<InputMaybe<Gas_Imports_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Gas_Imports_Filter>>>;
+  date?: InputMaybe<Date_Filter_Operators>;
+  date_func?: InputMaybe<Date_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  import_country?: InputMaybe<Countries_Filter>;
+  import_source?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Gas_Imports_Mutated = {
+  __typename?: 'gas_imports_mutated';
+  data?: Maybe<Gas_Imports>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Global_Co2_Concentration = {
+  __typename?: 'global_co2_concentration';
+  id: Scalars['ID']['output'];
+  mean?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Global_Co2_Concentration_Aggregated = {
+  __typename?: 'global_co2_concentration_aggregated';
+  avg?: Maybe<Global_Co2_Concentration_Aggregated_Fields>;
+  avgDistinct?: Maybe<Global_Co2_Concentration_Aggregated_Fields>;
+  count?: Maybe<Global_Co2_Concentration_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Global_Co2_Concentration_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Global_Co2_Concentration_Aggregated_Fields>;
+  min?: Maybe<Global_Co2_Concentration_Aggregated_Fields>;
+  sum?: Maybe<Global_Co2_Concentration_Aggregated_Fields>;
+  sumDistinct?: Maybe<Global_Co2_Concentration_Aggregated_Fields>;
+};
+
+export type Global_Co2_Concentration_Aggregated_Count = {
+  __typename?: 'global_co2_concentration_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  mean?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Global_Co2_Concentration_Aggregated_Fields = {
+  __typename?: 'global_co2_concentration_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  mean?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Global_Co2_Concentration_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Global_Co2_Concentration_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Global_Co2_Concentration_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  mean?: InputMaybe<Number_Filter_Operators>;
+  year?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Global_Co2_Concentration_Mutated = {
+  __typename?: 'global_co2_concentration_mutated';
+  data?: Maybe<Global_Co2_Concentration>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Glossary = {
+  __typename?: 'glossary';
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  key?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Array<Maybe<Glossary_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type GlossaryTranslationsArgs = {
+  filter?: InputMaybe<Glossary_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type GlossaryUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type GlossaryUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Glossary_Aggregated = {
+  __typename?: 'glossary_aggregated';
+  count?: Maybe<Glossary_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Glossary_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Glossary_Aggregated_Count = {
+  __typename?: 'glossary_aggregated_count';
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  key?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Glossary_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Glossary_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Glossary_Filter>>>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  key?: InputMaybe<String_Filter_Operators>;
+  status?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Glossary_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Glossary_Mutated = {
+  __typename?: 'glossary_mutated';
+  data?: Maybe<Glossary>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Glossary_Translations = {
+  __typename?: 'glossary_translations';
+  glossary_id?: Maybe<Glossary>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Glossary_TranslationsGlossary_IdArgs = {
+  filter?: InputMaybe<Glossary_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Glossary_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Glossary_Translations_Aggregated = {
+  __typename?: 'glossary_translations_aggregated';
+  avg?: Maybe<Glossary_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Glossary_Translations_Aggregated_Fields>;
+  count?: Maybe<Glossary_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Glossary_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Glossary_Translations_Aggregated_Fields>;
+  min?: Maybe<Glossary_Translations_Aggregated_Fields>;
+  sum?: Maybe<Glossary_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Glossary_Translations_Aggregated_Fields>;
+};
+
+export type Glossary_Translations_Aggregated_Count = {
+  __typename?: 'glossary_translations_aggregated_count';
+  glossary_id?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Glossary_Translations_Aggregated_Fields = {
+  __typename?: 'glossary_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Glossary_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Glossary_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Glossary_Translations_Filter>>>;
+  glossary_id?: InputMaybe<Glossary_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  text?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Glossary_Translations_Mutated = {
+  __typename?: 'glossary_translations_mutated';
+  data?: Maybe<Glossary_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Languages = {
+  __typename?: 'languages';
+  code: Scalars['ID']['output'];
+  direction?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type Languages_Aggregated = {
+  __typename?: 'languages_aggregated';
+  count?: Maybe<Languages_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Languages_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Languages_Aggregated_Count = {
+  __typename?: 'languages_aggregated_count';
+  code?: Maybe<Scalars['Int']['output']>;
+  direction?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Languages_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Languages_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Languages_Filter>>>;
+  code?: InputMaybe<String_Filter_Operators>;
+  direction?: InputMaybe<String_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Languages_Mutated = {
+  __typename?: 'languages_mutated';
+  data?: Maybe<Languages>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Mobility = {
+  __typename?: 'mobility';
+  category?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Mobility_Aggregated = {
+  __typename?: 'mobility_aggregated';
+  avg?: Maybe<Mobility_Aggregated_Fields>;
+  avgDistinct?: Maybe<Mobility_Aggregated_Fields>;
+  count?: Maybe<Mobility_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Mobility_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Mobility_Aggregated_Fields>;
+  min?: Maybe<Mobility_Aggregated_Fields>;
+  sum?: Maybe<Mobility_Aggregated_Fields>;
+  sumDistinct?: Maybe<Mobility_Aggregated_Fields>;
+};
+
+export type Mobility_Aggregated_Count = {
+  __typename?: 'mobility_aggregated_count';
+  category?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  note?: Maybe<Scalars['Int']['output']>;
+  period?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Mobility_Aggregated_Fields = {
+  __typename?: 'mobility_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Mobility_Cars = {
+  __typename?: 'mobility_cars';
+  category?: Maybe<Scalars['String']['output']>;
+  country?: Maybe<Countries>;
+  id: Scalars['ID']['output'];
+  period?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Mobility_CarsCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Mobility_Cars_Aggregated = {
+  __typename?: 'mobility_cars_aggregated';
+  avg?: Maybe<Mobility_Cars_Aggregated_Fields>;
+  avgDistinct?: Maybe<Mobility_Cars_Aggregated_Fields>;
+  count?: Maybe<Mobility_Cars_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Mobility_Cars_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Mobility_Cars_Aggregated_Fields>;
+  min?: Maybe<Mobility_Cars_Aggregated_Fields>;
+  sum?: Maybe<Mobility_Cars_Aggregated_Fields>;
+  sumDistinct?: Maybe<Mobility_Cars_Aggregated_Fields>;
+};
+
+export type Mobility_Cars_Aggregated_Count = {
+  __typename?: 'mobility_cars_aggregated_count';
+  category?: Maybe<Scalars['Int']['output']>;
+  country?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  period?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['Int']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Mobility_Cars_Aggregated_Fields = {
+  __typename?: 'mobility_cars_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Mobility_Cars_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Mobility_Cars_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Mobility_Cars_Filter>>>;
+  category?: InputMaybe<String_Filter_Operators>;
+  country?: InputMaybe<Countries_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  period?: InputMaybe<String_Filter_Operators>;
+  region?: InputMaybe<String_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Mobility_Cars_Mutated = {
+  __typename?: 'mobility_cars_mutated';
+  data?: Maybe<Mobility_Cars>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Mobility_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Mobility_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Mobility_Filter>>>;
+  category?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  note?: InputMaybe<String_Filter_Operators>;
+  period?: InputMaybe<String_Filter_Operators>;
+  region?: InputMaybe<String_Filter_Operators>;
+  source?: InputMaybe<String_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+  value?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Mobility_Mutated = {
+  __typename?: 'mobility_mutated';
+  data?: Maybe<Mobility>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type News = {
+  __typename?: 'news';
+  author?: Maybe<Directus_Users>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  sites?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  slack_message_id?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Array<Maybe<News_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type NewsAuthorArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type NewsTranslationsArgs = {
+  filter?: InputMaybe<News_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type News_Aggregated = {
+  __typename?: 'news_aggregated';
+  avg?: Maybe<News_Aggregated_Fields>;
+  avgDistinct?: Maybe<News_Aggregated_Fields>;
+  count?: Maybe<News_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<News_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<News_Aggregated_Fields>;
+  min?: Maybe<News_Aggregated_Fields>;
+  sum?: Maybe<News_Aggregated_Fields>;
+  sumDistinct?: Maybe<News_Aggregated_Fields>;
+};
+
+export type News_Aggregated_Count = {
+  __typename?: 'news_aggregated_count';
+  author?: Maybe<Scalars['Int']['output']>;
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  sites?: Maybe<Scalars['Int']['output']>;
+  slack_message_id?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type News_Aggregated_Fields = {
+  __typename?: 'news_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type News_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<News_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<News_Filter>>>;
+  author?: InputMaybe<Directus_Users_Filter>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  sites?: InputMaybe<String_Filter_Operators>;
+  slack_message_id?: InputMaybe<String_Filter_Operators>;
+  status?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<News_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type News_Mutated = {
+  __typename?: 'news_mutated';
+  data?: Maybe<News>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type News_Translations = {
+  __typename?: 'news_translations';
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  news_id?: Maybe<News>;
+  text?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type News_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type News_TranslationsNews_IdArgs = {
+  filter?: InputMaybe<News_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type News_Translations_Aggregated = {
+  __typename?: 'news_translations_aggregated';
+  avg?: Maybe<News_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<News_Translations_Aggregated_Fields>;
+  count?: Maybe<News_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<News_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<News_Translations_Aggregated_Fields>;
+  min?: Maybe<News_Translations_Aggregated_Fields>;
+  sum?: Maybe<News_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<News_Translations_Aggregated_Fields>;
+};
+
+export type News_Translations_Aggregated_Count = {
+  __typename?: 'news_translations_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  news_id?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+};
+
+export type News_Translations_Aggregated_Fields = {
+  __typename?: 'news_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  news_id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type News_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<News_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<News_Translations_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  news_id?: InputMaybe<News_Filter>;
+  text?: InputMaybe<String_Filter_Operators>;
+};
+
+export type News_Translations_Mutated = {
+  __typename?: 'news_translations_mutated';
+  data?: Maybe<News_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Number_Filter_Operators = {
+  _between?: InputMaybe<Array<InputMaybe<Scalars['GraphQLStringOrFloat']['input']>>>;
+  _eq?: InputMaybe<Scalars['GraphQLStringOrFloat']['input']>;
+  _gt?: InputMaybe<Scalars['GraphQLStringOrFloat']['input']>;
+  _gte?: InputMaybe<Scalars['GraphQLStringOrFloat']['input']>;
+  _in?: InputMaybe<Array<InputMaybe<Scalars['GraphQLStringOrFloat']['input']>>>;
+  _lt?: InputMaybe<Scalars['GraphQLStringOrFloat']['input']>;
+  _lte?: InputMaybe<Scalars['GraphQLStringOrFloat']['input']>;
+  _nbetween?: InputMaybe<Array<InputMaybe<Scalars['GraphQLStringOrFloat']['input']>>>;
+  _neq?: InputMaybe<Scalars['GraphQLStringOrFloat']['input']>;
+  _nin?: InputMaybe<Array<InputMaybe<Scalars['GraphQLStringOrFloat']['input']>>>;
+  _nnull?: InputMaybe<Scalars['Boolean']['input']>;
+  _null?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type Pages = {
+  __typename?: 'pages';
+  blocks?: Maybe<Array<Maybe<Pages_Blocks>>>;
+  blocks_func?: Maybe<Count_Functions>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  site?: Maybe<Sites>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Array<Maybe<Pages_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type PagesBlocksArgs = {
+  filter?: InputMaybe<Pages_Blocks_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PagesSiteArgs = {
+  filter?: InputMaybe<Sites_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PagesTranslationsArgs = {
+  filter?: InputMaybe<Pages_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PagesUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PagesUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Pages_Aggregated = {
+  __typename?: 'pages_aggregated';
+  avg?: Maybe<Pages_Aggregated_Fields>;
+  avgDistinct?: Maybe<Pages_Aggregated_Fields>;
+  count?: Maybe<Pages_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Pages_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Pages_Aggregated_Fields>;
+  min?: Maybe<Pages_Aggregated_Fields>;
+  sum?: Maybe<Pages_Aggregated_Fields>;
+  sumDistinct?: Maybe<Pages_Aggregated_Fields>;
+};
+
+export type Pages_Aggregated_Count = {
+  __typename?: 'pages_aggregated_count';
+  blocks?: Maybe<Scalars['Int']['output']>;
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  site?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Pages_Aggregated_Fields = {
+  __typename?: 'pages_aggregated_fields';
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Pages_Blocks = {
+  __typename?: 'pages_blocks';
+  collection?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  item?: Maybe<Pages_Blocks_Item_Union>;
+  pages_id?: Maybe<Pages>;
+  sort?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Pages_BlocksPages_IdArgs = {
+  filter?: InputMaybe<Pages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Pages_Blocks_Aggregated = {
+  __typename?: 'pages_blocks_aggregated';
+  avg?: Maybe<Pages_Blocks_Aggregated_Fields>;
+  avgDistinct?: Maybe<Pages_Blocks_Aggregated_Fields>;
+  count?: Maybe<Pages_Blocks_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Pages_Blocks_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Pages_Blocks_Aggregated_Fields>;
+  min?: Maybe<Pages_Blocks_Aggregated_Fields>;
+  sum?: Maybe<Pages_Blocks_Aggregated_Fields>;
+  sumDistinct?: Maybe<Pages_Blocks_Aggregated_Fields>;
+};
+
+export type Pages_Blocks_Aggregated_Count = {
+  __typename?: 'pages_blocks_aggregated_count';
+  collection?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  item?: Maybe<Scalars['Int']['output']>;
+  pages_id?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Pages_Blocks_Aggregated_Fields = {
+  __typename?: 'pages_blocks_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Pages_Blocks_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Pages_Blocks_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Pages_Blocks_Filter>>>;
+  collection?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  item__block_chart?: InputMaybe<Block_Chart_Filter>;
+  item__block_donation?: InputMaybe<Block_Donation_Filter>;
+  item__block_gallery?: InputMaybe<Block_Gallery_Filter>;
+  item__block_grid?: InputMaybe<Block_Grid_Filter>;
+  item__block_items?: InputMaybe<Block_Items_Filter>;
+  item__block_news?: InputMaybe<Block_News_Filter>;
+  item__block_panel?: InputMaybe<Block_Panel_Filter>;
+  item__block_quiz?: InputMaybe<Block_Quiz_Filter>;
+  item__block_quotes?: InputMaybe<Block_Quotes_Filter>;
+  item__block_richtext?: InputMaybe<Block_Richtext_Filter>;
+  item__block_teaser?: InputMaybe<Block_Teaser_Filter>;
+  item__block_toggle?: InputMaybe<Block_Toggle_Filter>;
+  pages_id?: InputMaybe<Pages_Filter>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Pages_Blocks_Item_Union = Block_Chart | Block_Donation | Block_Gallery | Block_Grid | Block_Items | Block_News | Block_Panel | Block_Quiz | Block_Quotes | Block_Richtext | Block_Teaser | Block_Toggle;
+
+export type Pages_Blocks_Mutated = {
+  __typename?: 'pages_blocks_mutated';
+  data?: Maybe<Pages_Blocks>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Pages_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Pages_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Pages_Filter>>>;
+  blocks?: InputMaybe<Pages_Blocks_Filter>;
+  blocks_func?: InputMaybe<Count_Function_Filter_Operators>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  site?: InputMaybe<Sites_Filter>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+  status?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Pages_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Pages_Mutated = {
+  __typename?: 'pages_mutated';
+  data?: Maybe<Pages>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Pages_Translations = {
+  __typename?: 'pages_translations';
+  description?: Maybe<Scalars['String']['output']>;
+  heading?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  pages_id?: Maybe<Pages>;
+  seo?: Maybe<Seo>;
+  slug?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Pages_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Pages_TranslationsPages_IdArgs = {
+  filter?: InputMaybe<Pages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Pages_TranslationsSeoArgs = {
+  filter?: InputMaybe<Seo_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Pages_Translations_Aggregated = {
+  __typename?: 'pages_translations_aggregated';
+  avg?: Maybe<Pages_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Pages_Translations_Aggregated_Fields>;
+  count?: Maybe<Pages_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Pages_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Pages_Translations_Aggregated_Fields>;
+  min?: Maybe<Pages_Translations_Aggregated_Fields>;
+  sum?: Maybe<Pages_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Pages_Translations_Aggregated_Fields>;
+};
+
+export type Pages_Translations_Aggregated_Count = {
+  __typename?: 'pages_translations_aggregated_count';
+  description?: Maybe<Scalars['Int']['output']>;
+  heading?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  pages_id?: Maybe<Scalars['Int']['output']>;
+  seo?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['Int']['output']>;
+  tags?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Pages_Translations_Aggregated_Fields = {
+  __typename?: 'pages_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Pages_Translations_Blocks = {
+  __typename?: 'pages_translations_blocks';
+  collection?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  item?: Maybe<Pages_Translations_Blocks_Item_Union>;
+  pages_translations_id?: Maybe<Pages_Translations>;
+  sort?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type Pages_Translations_BlocksPages_Translations_IdArgs = {
+  filter?: InputMaybe<Pages_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Pages_Translations_Blocks_Aggregated = {
+  __typename?: 'pages_translations_blocks_aggregated';
+  avg?: Maybe<Pages_Translations_Blocks_Aggregated_Fields>;
+  avgDistinct?: Maybe<Pages_Translations_Blocks_Aggregated_Fields>;
+  count?: Maybe<Pages_Translations_Blocks_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Pages_Translations_Blocks_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Pages_Translations_Blocks_Aggregated_Fields>;
+  min?: Maybe<Pages_Translations_Blocks_Aggregated_Fields>;
+  sum?: Maybe<Pages_Translations_Blocks_Aggregated_Fields>;
+  sumDistinct?: Maybe<Pages_Translations_Blocks_Aggregated_Fields>;
+};
+
+export type Pages_Translations_Blocks_Aggregated_Count = {
+  __typename?: 'pages_translations_blocks_aggregated_count';
+  collection?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  item?: Maybe<Scalars['Int']['output']>;
+  pages_translations_id?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Pages_Translations_Blocks_Aggregated_Fields = {
+  __typename?: 'pages_translations_blocks_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  pages_translations_id?: Maybe<Scalars['Float']['output']>;
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Pages_Translations_Blocks_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Pages_Translations_Blocks_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Pages_Translations_Blocks_Filter>>>;
+  collection?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  item__block_chart?: InputMaybe<Block_Chart_Filter>;
+  item__block_donation?: InputMaybe<Block_Donation_Filter>;
+  item__block_gallery?: InputMaybe<Block_Gallery_Filter>;
+  item__block_grid?: InputMaybe<Block_Grid_Filter>;
+  item__block_items?: InputMaybe<Block_Items_Filter>;
+  item__block_quiz?: InputMaybe<Block_Quiz_Filter>;
+  item__block_quotes?: InputMaybe<Block_Quotes_Filter>;
+  item__block_richtext?: InputMaybe<Block_Richtext_Filter>;
+  item__block_teaser?: InputMaybe<Block_Teaser_Filter>;
+  item__block_toggle?: InputMaybe<Block_Toggle_Filter>;
+  pages_translations_id?: InputMaybe<Pages_Translations_Filter>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Pages_Translations_Blocks_Item_Union = Block_Chart | Block_Donation | Block_Gallery | Block_Grid | Block_Items | Block_Quiz | Block_Quotes | Block_Richtext | Block_Teaser | Block_Toggle;
+
+export type Pages_Translations_Blocks_Mutated = {
+  __typename?: 'pages_translations_blocks_mutated';
+  data?: Maybe<Pages_Translations_Blocks>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Pages_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Pages_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Pages_Translations_Filter>>>;
+  description?: InputMaybe<String_Filter_Operators>;
+  heading?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  pages_id?: InputMaybe<Pages_Filter>;
+  seo?: InputMaybe<Seo_Filter>;
+  slug?: InputMaybe<String_Filter_Operators>;
+  tags?: InputMaybe<String_Filter_Operators>;
+  tags_func?: InputMaybe<Count_Function_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Pages_Translations_Mutated = {
+  __typename?: 'pages_translations_mutated';
+  data?: Maybe<Pages_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies = {
+  __typename?: 'policies';
+  attributes?: Maybe<Array<Maybe<Policies_Policies_Attributes>>>;
+  attributes_func?: Maybe<Count_Functions>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  rating?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  stakeholders?: Maybe<Array<Maybe<Policies_Stakeholders>>>;
+  stakeholders_func?: Maybe<Count_Functions>;
+  status?: Maybe<Policies_Status>;
+  translations?: Maybe<Array<Maybe<Policies_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  updates?: Maybe<Array<Maybe<Policies_Updates>>>;
+  updates_func?: Maybe<Count_Functions>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type PoliciesAttributesArgs = {
+  filter?: InputMaybe<Policies_Policies_Attributes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PoliciesStakeholdersArgs = {
+  filter?: InputMaybe<Policies_Stakeholders_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PoliciesStatusArgs = {
+  filter?: InputMaybe<Policies_Status_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PoliciesTranslationsArgs = {
+  filter?: InputMaybe<Policies_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PoliciesUpdatesArgs = {
+  filter?: InputMaybe<Policies_Updates_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PoliciesUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type PoliciesUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Aggregated = {
+  __typename?: 'policies_aggregated';
+  avg?: Maybe<Policies_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Aggregated_Fields>;
+  count?: Maybe<Policies_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Aggregated_Fields>;
+  min?: Maybe<Policies_Aggregated_Fields>;
+  sum?: Maybe<Policies_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Aggregated_Fields>;
+};
+
+export type Policies_Aggregated_Count = {
+  __typename?: 'policies_aggregated_count';
+  attributes?: Maybe<Scalars['Int']['output']>;
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  rating?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  stakeholders?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  updates?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Aggregated_Fields = {
+  __typename?: 'policies_aggregated_fields';
+  rating?: Maybe<Scalars['Float']['output']>;
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Attributes = {
+  __typename?: 'policies_attributes';
+  icon?: Maybe<Scalars['String']['output']>;
+  key: Scalars['ID']['output'];
+  translations?: Maybe<Array<Maybe<Policies_Attributes_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  type?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Policies_AttributesTranslationsArgs = {
+  filter?: InputMaybe<Policies_Attributes_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Attributes_Aggregated = {
+  __typename?: 'policies_attributes_aggregated';
+  count?: Maybe<Policies_Attributes_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Attributes_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Policies_Attributes_Aggregated_Count = {
+  __typename?: 'policies_attributes_aggregated_count';
+  icon?: Maybe<Scalars['Int']['output']>;
+  key?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Attributes_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Attributes_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Attributes_Filter>>>;
+  icon?: InputMaybe<String_Filter_Operators>;
+  key?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Policies_Attributes_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  type?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Policies_Attributes_Mutated = {
+  __typename?: 'policies_attributes_mutated';
+  data?: Maybe<Policies_Attributes>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Attributes_Translations = {
+  __typename?: 'policies_attributes_translations';
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  policies_attributes_key?: Maybe<Policies_Attributes>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Policies_Attributes_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_Attributes_TranslationsPolicies_Attributes_KeyArgs = {
+  filter?: InputMaybe<Policies_Attributes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Attributes_Translations_Aggregated = {
+  __typename?: 'policies_attributes_translations_aggregated';
+  avg?: Maybe<Policies_Attributes_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Attributes_Translations_Aggregated_Fields>;
+  count?: Maybe<Policies_Attributes_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Attributes_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Attributes_Translations_Aggregated_Fields>;
+  min?: Maybe<Policies_Attributes_Translations_Aggregated_Fields>;
+  sum?: Maybe<Policies_Attributes_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Attributes_Translations_Aggregated_Fields>;
+};
+
+export type Policies_Attributes_Translations_Aggregated_Count = {
+  __typename?: 'policies_attributes_translations_aggregated_count';
+  description?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  policies_attributes_key?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Attributes_Translations_Aggregated_Fields = {
+  __typename?: 'policies_attributes_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Attributes_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Attributes_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Attributes_Translations_Filter>>>;
+  description?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  policies_attributes_key?: InputMaybe<Policies_Attributes_Filter>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Policies_Attributes_Translations_Mutated = {
+  __typename?: 'policies_attributes_translations_mutated';
+  data?: Maybe<Policies_Attributes_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Filter>>>;
+  attributes?: InputMaybe<Policies_Policies_Attributes_Filter>;
+  attributes_func?: InputMaybe<Count_Function_Filter_Operators>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  rating?: InputMaybe<Number_Filter_Operators>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+  stakeholders?: InputMaybe<Policies_Stakeholders_Filter>;
+  stakeholders_func?: InputMaybe<Count_Function_Filter_Operators>;
+  status?: InputMaybe<Policies_Status_Filter>;
+  translations?: InputMaybe<Policies_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  updates?: InputMaybe<Policies_Updates_Filter>;
+  updates_func?: InputMaybe<Count_Function_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Policies_Mutated = {
+  __typename?: 'policies_mutated';
+  data?: Maybe<Policies>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Policies_Attributes = {
+  __typename?: 'policies_policies_attributes';
+  id: Scalars['ID']['output'];
+  policies_attributes_key?: Maybe<Policies_Attributes>;
+  policies_id?: Maybe<Policies>;
+};
+
+
+export type Policies_Policies_AttributesPolicies_Attributes_KeyArgs = {
+  filter?: InputMaybe<Policies_Attributes_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_Policies_AttributesPolicies_IdArgs = {
+  filter?: InputMaybe<Policies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Policies_Attributes_Aggregated = {
+  __typename?: 'policies_policies_attributes_aggregated';
+  avg?: Maybe<Policies_Policies_Attributes_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Policies_Attributes_Aggregated_Fields>;
+  count?: Maybe<Policies_Policies_Attributes_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Policies_Attributes_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Policies_Attributes_Aggregated_Fields>;
+  min?: Maybe<Policies_Policies_Attributes_Aggregated_Fields>;
+  sum?: Maybe<Policies_Policies_Attributes_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Policies_Attributes_Aggregated_Fields>;
+};
+
+export type Policies_Policies_Attributes_Aggregated_Count = {
+  __typename?: 'policies_policies_attributes_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  policies_attributes_key?: Maybe<Scalars['Int']['output']>;
+  policies_id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Policies_Attributes_Aggregated_Fields = {
+  __typename?: 'policies_policies_attributes_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Policies_Attributes_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Policies_Attributes_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Policies_Attributes_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  policies_attributes_key?: InputMaybe<Policies_Attributes_Filter>;
+  policies_id?: InputMaybe<Policies_Filter>;
+};
+
+export type Policies_Policies_Attributes_Mutated = {
+  __typename?: 'policies_policies_attributes_mutated';
+  data?: Maybe<Policies_Policies_Attributes>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Stakeholders = {
+  __typename?: 'policies_stakeholders';
+  id: Scalars['ID']['output'];
+  policies_id?: Maybe<Policies>;
+  stakeholders_id?: Maybe<Stakeholders>;
+};
+
+
+export type Policies_StakeholdersPolicies_IdArgs = {
+  filter?: InputMaybe<Policies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_StakeholdersStakeholders_IdArgs = {
+  filter?: InputMaybe<Stakeholders_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Stakeholders_Aggregated = {
+  __typename?: 'policies_stakeholders_aggregated';
+  avg?: Maybe<Policies_Stakeholders_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Stakeholders_Aggregated_Fields>;
+  count?: Maybe<Policies_Stakeholders_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Stakeholders_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Stakeholders_Aggregated_Fields>;
+  min?: Maybe<Policies_Stakeholders_Aggregated_Fields>;
+  sum?: Maybe<Policies_Stakeholders_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Stakeholders_Aggregated_Fields>;
+};
+
+export type Policies_Stakeholders_Aggregated_Count = {
+  __typename?: 'policies_stakeholders_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  policies_id?: Maybe<Scalars['Int']['output']>;
+  stakeholders_id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Stakeholders_Aggregated_Fields = {
+  __typename?: 'policies_stakeholders_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Stakeholders_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Stakeholders_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Stakeholders_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  policies_id?: InputMaybe<Policies_Filter>;
+  stakeholders_id?: InputMaybe<Stakeholders_Filter>;
+};
+
+export type Policies_Stakeholders_Mutated = {
+  __typename?: 'policies_stakeholders_mutated';
+  data?: Maybe<Policies_Stakeholders>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Status = {
+  __typename?: 'policies_status';
+  color?: Maybe<Scalars['String']['output']>;
+  colorText?: Maybe<Scalars['String']['output']>;
+  icon?: Maybe<Scalars['String']['output']>;
+  key: Scalars['ID']['output'];
+  sort?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Array<Maybe<Policies_Status_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type Policies_StatusTranslationsArgs = {
+  filter?: InputMaybe<Policies_Status_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Status_Aggregated = {
+  __typename?: 'policies_status_aggregated';
+  avg?: Maybe<Policies_Status_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Status_Aggregated_Fields>;
+  count?: Maybe<Policies_Status_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Status_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Status_Aggregated_Fields>;
+  min?: Maybe<Policies_Status_Aggregated_Fields>;
+  sum?: Maybe<Policies_Status_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Status_Aggregated_Fields>;
+};
+
+export type Policies_Status_Aggregated_Count = {
+  __typename?: 'policies_status_aggregated_count';
+  color?: Maybe<Scalars['Int']['output']>;
+  colorText?: Maybe<Scalars['Int']['output']>;
+  icon?: Maybe<Scalars['Int']['output']>;
+  key?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Status_Aggregated_Fields = {
+  __typename?: 'policies_status_aggregated_fields';
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Status_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Status_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Status_Filter>>>;
+  color?: InputMaybe<String_Filter_Operators>;
+  colorText?: InputMaybe<String_Filter_Operators>;
+  icon?: InputMaybe<String_Filter_Operators>;
+  key?: InputMaybe<String_Filter_Operators>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+  translations?: InputMaybe<Policies_Status_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Policies_Status_Mutated = {
+  __typename?: 'policies_status_mutated';
+  data?: Maybe<Policies_Status>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Status_Translations = {
+  __typename?: 'policies_status_translations';
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  label?: Maybe<Scalars['String']['output']>;
+  languages_code?: Maybe<Languages>;
+  policies_status_key?: Maybe<Policies_Status>;
+};
+
+
+export type Policies_Status_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_Status_TranslationsPolicies_Status_KeyArgs = {
+  filter?: InputMaybe<Policies_Status_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Status_Translations_Aggregated = {
+  __typename?: 'policies_status_translations_aggregated';
+  avg?: Maybe<Policies_Status_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Status_Translations_Aggregated_Fields>;
+  count?: Maybe<Policies_Status_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Status_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Status_Translations_Aggregated_Fields>;
+  min?: Maybe<Policies_Status_Translations_Aggregated_Fields>;
+  sum?: Maybe<Policies_Status_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Status_Translations_Aggregated_Fields>;
+};
+
+export type Policies_Status_Translations_Aggregated_Count = {
+  __typename?: 'policies_status_translations_aggregated_count';
+  description?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  label?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  policies_status_key?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Status_Translations_Aggregated_Fields = {
+  __typename?: 'policies_status_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Status_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Status_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Status_Translations_Filter>>>;
+  description?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  label?: InputMaybe<String_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  policies_status_key?: InputMaybe<Policies_Status_Filter>;
+};
+
+export type Policies_Status_Translations_Mutated = {
+  __typename?: 'policies_status_translations_mutated';
+  data?: Maybe<Policies_Status_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Translations = {
+  __typename?: 'policies_translations';
+  citizenDemand?: Maybe<Scalars['String']['output']>;
+  content?: Maybe<Scalars['String']['output']>;
+  governmentPlan?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  policies_id?: Maybe<Policies>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Policies_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_TranslationsPolicies_IdArgs = {
+  filter?: InputMaybe<Policies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Translations_Aggregated = {
+  __typename?: 'policies_translations_aggregated';
+  avg?: Maybe<Policies_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Translations_Aggregated_Fields>;
+  count?: Maybe<Policies_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Translations_Aggregated_Fields>;
+  min?: Maybe<Policies_Translations_Aggregated_Fields>;
+  sum?: Maybe<Policies_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Translations_Aggregated_Fields>;
+};
+
+export type Policies_Translations_Aggregated_Count = {
+  __typename?: 'policies_translations_aggregated_count';
+  citizenDemand?: Maybe<Scalars['Int']['output']>;
+  content?: Maybe<Scalars['Int']['output']>;
+  governmentPlan?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  policies_id?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Translations_Aggregated_Fields = {
+  __typename?: 'policies_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Translations_Filter>>>;
+  citizenDemand?: InputMaybe<String_Filter_Operators>;
+  content?: InputMaybe<String_Filter_Operators>;
+  governmentPlan?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  policies_id?: InputMaybe<Policies_Filter>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Policies_Translations_Mutated = {
+  __typename?: 'policies_translations_mutated';
+  data?: Maybe<Policies_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Updates = {
+  __typename?: 'policies_updates';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  policy?: Maybe<Policies>;
+  translations?: Maybe<Array<Maybe<Policies_Updates_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type Policies_UpdatesPolicyArgs = {
+  filter?: InputMaybe<Policies_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_UpdatesTranslationsArgs = {
+  filter?: InputMaybe<Policies_Updates_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_UpdatesUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Updates_Aggregated = {
+  __typename?: 'policies_updates_aggregated';
+  count?: Maybe<Policies_Updates_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Updates_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Policies_Updates_Aggregated_Count = {
+  __typename?: 'policies_updates_aggregated_count';
+  date?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  policy?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Updates_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Updates_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Updates_Filter>>>;
+  date?: InputMaybe<Date_Filter_Operators>;
+  date_func?: InputMaybe<Date_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  policy?: InputMaybe<Policies_Filter>;
+  translations?: InputMaybe<Policies_Updates_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Policies_Updates_Mutated = {
+  __typename?: 'policies_updates_mutated';
+  data?: Maybe<Policies_Updates>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Policies_Updates_Translations = {
+  __typename?: 'policies_updates_translations';
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  policies_updates_id?: Maybe<Policies_Updates>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Policies_Updates_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Policies_Updates_TranslationsPolicies_Updates_IdArgs = {
+  filter?: InputMaybe<Policies_Updates_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Policies_Updates_Translations_Aggregated = {
+  __typename?: 'policies_updates_translations_aggregated';
+  avg?: Maybe<Policies_Updates_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Policies_Updates_Translations_Aggregated_Fields>;
+  count?: Maybe<Policies_Updates_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Policies_Updates_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Policies_Updates_Translations_Aggregated_Fields>;
+  min?: Maybe<Policies_Updates_Translations_Aggregated_Fields>;
+  sum?: Maybe<Policies_Updates_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Policies_Updates_Translations_Aggregated_Fields>;
+};
+
+export type Policies_Updates_Translations_Aggregated_Count = {
+  __typename?: 'policies_updates_translations_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  policies_updates_id?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Policies_Updates_Translations_Aggregated_Fields = {
+  __typename?: 'policies_updates_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Policies_Updates_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Policies_Updates_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Policies_Updates_Translations_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  policies_updates_id?: InputMaybe<Policies_Updates_Filter>;
+  text?: InputMaybe<String_Filter_Operators>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Policies_Updates_Translations_Mutated = {
+  __typename?: 'policies_updates_translations_mutated';
+  data?: Maybe<Policies_Updates_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Pv_Produktion = {
+  __typename?: 'pv_produktion';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  PV?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  unit?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Pv_ProduktionCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Pv_Produktion_Aggregated = {
+  __typename?: 'pv_produktion_aggregated';
+  avg?: Maybe<Pv_Produktion_Aggregated_Fields>;
+  avgDistinct?: Maybe<Pv_Produktion_Aggregated_Fields>;
+  count?: Maybe<Pv_Produktion_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Pv_Produktion_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Pv_Produktion_Aggregated_Fields>;
+  min?: Maybe<Pv_Produktion_Aggregated_Fields>;
+  sum?: Maybe<Pv_Produktion_Aggregated_Fields>;
+  sumDistinct?: Maybe<Pv_Produktion_Aggregated_Fields>;
+};
+
+export type Pv_Produktion_Aggregated_Count = {
+  __typename?: 'pv_produktion_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  PV?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Pv_Produktion_Aggregated_Fields = {
+  __typename?: 'pv_produktion_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  PV?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Pv_Produktion_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  PV?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Pv_Produktion_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Pv_Produktion_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  unit?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Pv_Produktion_Mutated = {
+  __typename?: 'pv_produktion_mutated';
+  data?: Maybe<Pv_Produktion>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Pv_Zielpfad = {
+  __typename?: 'pv_zielpfad';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Pv_ZielpfadCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Pv_Zielpfad_Aggregated = {
+  __typename?: 'pv_zielpfad_aggregated';
+  avg?: Maybe<Pv_Zielpfad_Aggregated_Fields>;
+  avgDistinct?: Maybe<Pv_Zielpfad_Aggregated_Fields>;
+  count?: Maybe<Pv_Zielpfad_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Pv_Zielpfad_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Pv_Zielpfad_Aggregated_Fields>;
+  min?: Maybe<Pv_Zielpfad_Aggregated_Fields>;
+  sum?: Maybe<Pv_Zielpfad_Aggregated_Fields>;
+  sumDistinct?: Maybe<Pv_Zielpfad_Aggregated_Fields>;
+};
+
+export type Pv_Zielpfad_Aggregated_Count = {
+  __typename?: 'pv_zielpfad_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Pv_Zielpfad_Aggregated_Fields = {
+  __typename?: 'pv_zielpfad_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Pv_Zielpfad_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Date_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Pv_Zielpfad_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Pv_Zielpfad_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Pv_Zielpfad_Mutated = {
+  __typename?: 'pv_zielpfad_mutated';
+  data?: Maybe<Pv_Zielpfad>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Quiz_Answers = {
+  __typename?: 'quiz_answers';
+  answer_count?: Maybe<Scalars['Int']['output']>;
+  answer_order?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  is_true?: Maybe<Scalars['Boolean']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  question_id?: Maybe<Quiz_Questions>;
+  text?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Quiz_AnswersQuestion_IdArgs = {
+  filter?: InputMaybe<Quiz_Questions_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Quiz_Answers_Aggregated = {
+  __typename?: 'quiz_answers_aggregated';
+  avg?: Maybe<Quiz_Answers_Aggregated_Fields>;
+  avgDistinct?: Maybe<Quiz_Answers_Aggregated_Fields>;
+  count?: Maybe<Quiz_Answers_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Quiz_Answers_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Quiz_Answers_Aggregated_Fields>;
+  min?: Maybe<Quiz_Answers_Aggregated_Fields>;
+  sum?: Maybe<Quiz_Answers_Aggregated_Fields>;
+  sumDistinct?: Maybe<Quiz_Answers_Aggregated_Fields>;
+};
+
+export type Quiz_Answers_Aggregated_Count = {
+  __typename?: 'quiz_answers_aggregated_count';
+  answer_count?: Maybe<Scalars['Int']['output']>;
+  answer_order?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  is_true?: Maybe<Scalars['Int']['output']>;
+  label?: Maybe<Scalars['Int']['output']>;
+  question_id?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Quiz_Answers_Aggregated_Fields = {
+  __typename?: 'quiz_answers_aggregated_fields';
+  answer_count?: Maybe<Scalars['Float']['output']>;
+  answer_order?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Quiz_Answers_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Quiz_Answers_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Quiz_Answers_Filter>>>;
+  answer_count?: InputMaybe<Number_Filter_Operators>;
+  answer_order?: InputMaybe<Number_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  is_true?: InputMaybe<Boolean_Filter_Operators>;
+  label?: InputMaybe<String_Filter_Operators>;
+  question_id?: InputMaybe<Quiz_Questions_Filter>;
+  text?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Quiz_Answers_Mutated = {
+  __typename?: 'quiz_answers_mutated';
+  data?: Maybe<Quiz_Answers>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Quiz_Questions = {
+  __typename?: 'quiz_questions';
+  answers?: Maybe<Array<Maybe<Quiz_Answers>>>;
+  answers_func?: Maybe<Count_Functions>;
+  countries?: Maybe<Scalars['JSON']['output']>;
+  countries_func?: Maybe<Count_Functions>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  question?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  text_answer?: Maybe<Scalars['String']['output']>;
+  text_question?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type Quiz_QuestionsAnswersArgs = {
+  filter?: InputMaybe<Quiz_Answers_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Quiz_QuestionsUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Quiz_QuestionsUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Quiz_Questions_Aggregated = {
+  __typename?: 'quiz_questions_aggregated';
+  count?: Maybe<Quiz_Questions_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Quiz_Questions_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Quiz_Questions_Aggregated_Count = {
+  __typename?: 'quiz_questions_aggregated_count';
+  answers?: Maybe<Scalars['Int']['output']>;
+  countries?: Maybe<Scalars['Int']['output']>;
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  question?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  text_answer?: Maybe<Scalars['Int']['output']>;
+  text_question?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Quiz_Questions_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Quiz_Questions_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Quiz_Questions_Filter>>>;
+  answers?: InputMaybe<Quiz_Answers_Filter>;
+  answers_func?: InputMaybe<Count_Function_Filter_Operators>;
+  countries?: InputMaybe<String_Filter_Operators>;
+  countries_func?: InputMaybe<Count_Function_Filter_Operators>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  question?: InputMaybe<String_Filter_Operators>;
+  status?: InputMaybe<String_Filter_Operators>;
+  text_answer?: InputMaybe<String_Filter_Operators>;
+  text_question?: InputMaybe<String_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Quiz_Questions_Mutated = {
+  __typename?: 'quiz_questions_mutated';
+  data?: Maybe<Quiz_Questions>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Quotes = {
+  __typename?: 'quotes';
+  author_image?: Maybe<Directus_Files>;
+  author_image_copyright?: Maybe<Scalars['String']['output']>;
+  author_name?: Maybe<Scalars['String']['output']>;
+  author_role?: Maybe<Scalars['String']['output']>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  sort?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type QuotesAuthor_ImageArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuotesUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QuotesUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Quotes_Aggregated = {
+  __typename?: 'quotes_aggregated';
+  avg?: Maybe<Quotes_Aggregated_Fields>;
+  avgDistinct?: Maybe<Quotes_Aggregated_Fields>;
+  count?: Maybe<Quotes_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Quotes_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Quotes_Aggregated_Fields>;
+  min?: Maybe<Quotes_Aggregated_Fields>;
+  sum?: Maybe<Quotes_Aggregated_Fields>;
+  sumDistinct?: Maybe<Quotes_Aggregated_Fields>;
+};
+
+export type Quotes_Aggregated_Count = {
+  __typename?: 'quotes_aggregated_count';
+  author_image?: Maybe<Scalars['Int']['output']>;
+  author_image_copyright?: Maybe<Scalars['Int']['output']>;
+  author_name?: Maybe<Scalars['Int']['output']>;
+  author_role?: Maybe<Scalars['Int']['output']>;
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['Int']['output']>;
+  text?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Quotes_Aggregated_Fields = {
+  __typename?: 'quotes_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  sort?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Quotes_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Quotes_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Quotes_Filter>>>;
+  author_image?: InputMaybe<Directus_Files_Filter>;
+  author_image_copyright?: InputMaybe<String_Filter_Operators>;
+  author_name?: InputMaybe<String_Filter_Operators>;
+  author_role?: InputMaybe<String_Filter_Operators>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  sort?: InputMaybe<Number_Filter_Operators>;
+  status?: InputMaybe<String_Filter_Operators>;
+  text?: InputMaybe<String_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Quotes_Mutated = {
+  __typename?: 'quotes_mutated';
+  data?: Maybe<Quotes>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Regions = {
+  __typename?: 'regions';
+  area?: Maybe<Scalars['Int']['output']>;
+  attributes?: Maybe<Scalars['JSON']['output']>;
+  attributes_func?: Maybe<Count_Functions>;
+  center?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  code?: Maybe<Scalars['String']['output']>;
+  country?: Maybe<Countries>;
+  id: Scalars['ID']['output'];
+  layer?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  name_short?: Maybe<Scalars['String']['output']>;
+  nuts?: Maybe<Scalars['String']['output']>;
+  outline?: Maybe<Scalars['JSON']['output']>;
+  outline_func?: Maybe<Count_Functions>;
+  outline_simple?: Maybe<Scalars['JSON']['output']>;
+  outline_simple_func?: Maybe<Count_Functions>;
+  population?: Maybe<Scalars['Int']['output']>;
+  postcodes?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+};
+
+
+export type RegionsCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Regions_Aggregated = {
+  __typename?: 'regions_aggregated';
+  avg?: Maybe<Regions_Aggregated_Fields>;
+  avgDistinct?: Maybe<Regions_Aggregated_Fields>;
+  count?: Maybe<Regions_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Regions_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Regions_Aggregated_Fields>;
+  min?: Maybe<Regions_Aggregated_Fields>;
+  sum?: Maybe<Regions_Aggregated_Fields>;
+  sumDistinct?: Maybe<Regions_Aggregated_Fields>;
+};
+
+export type Regions_Aggregated_Count = {
+  __typename?: 'regions_aggregated_count';
+  area?: Maybe<Scalars['Int']['output']>;
+  attributes?: Maybe<Scalars['Int']['output']>;
+  center?: Maybe<Scalars['Int']['output']>;
+  code?: Maybe<Scalars['Int']['output']>;
+  country?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  layer?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['Int']['output']>;
+  name_short?: Maybe<Scalars['Int']['output']>;
+  nuts?: Maybe<Scalars['Int']['output']>;
+  outline?: Maybe<Scalars['Int']['output']>;
+  outline_simple?: Maybe<Scalars['Int']['output']>;
+  population?: Maybe<Scalars['Int']['output']>;
+  postcodes?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Regions_Aggregated_Fields = {
+  __typename?: 'regions_aggregated_fields';
+  area?: Maybe<Scalars['Float']['output']>;
+  population?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Regions_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Regions_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Regions_Filter>>>;
+  area?: InputMaybe<Number_Filter_Operators>;
+  attributes?: InputMaybe<String_Filter_Operators>;
+  attributes_func?: InputMaybe<Count_Function_Filter_Operators>;
+  center?: InputMaybe<String_Filter_Operators>;
+  code?: InputMaybe<String_Filter_Operators>;
+  country?: InputMaybe<Countries_Filter>;
+  id?: InputMaybe<String_Filter_Operators>;
+  layer?: InputMaybe<String_Filter_Operators>;
+  name?: InputMaybe<String_Filter_Operators>;
+  name_short?: InputMaybe<String_Filter_Operators>;
+  nuts?: InputMaybe<String_Filter_Operators>;
+  outline?: InputMaybe<String_Filter_Operators>;
+  outline_func?: InputMaybe<Count_Function_Filter_Operators>;
+  outline_simple?: InputMaybe<String_Filter_Operators>;
+  outline_simple_func?: InputMaybe<Count_Function_Filter_Operators>;
+  population?: InputMaybe<Number_Filter_Operators>;
+  postcodes?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Regions_Mutated = {
+  __typename?: 'regions_mutated';
+  data?: Maybe<Regions>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Renewable_Share_15min = {
+  __typename?: 'renewable_share_15min';
+  country?: Maybe<Countries>;
+  id: Scalars['ID']['output'];
+  share?: Maybe<Scalars['Float']['output']>;
+  time?: Maybe<Scalars['Date']['output']>;
+  time_func?: Maybe<Datetime_Functions>;
+};
+
+
+export type Renewable_Share_15minCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Renewable_Share_15min_Aggregated = {
+  __typename?: 'renewable_share_15min_aggregated';
+  avg?: Maybe<Renewable_Share_15min_Aggregated_Fields>;
+  avgDistinct?: Maybe<Renewable_Share_15min_Aggregated_Fields>;
+  count?: Maybe<Renewable_Share_15min_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Renewable_Share_15min_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Renewable_Share_15min_Aggregated_Fields>;
+  min?: Maybe<Renewable_Share_15min_Aggregated_Fields>;
+  sum?: Maybe<Renewable_Share_15min_Aggregated_Fields>;
+  sumDistinct?: Maybe<Renewable_Share_15min_Aggregated_Fields>;
+};
+
+export type Renewable_Share_15min_Aggregated_Count = {
+  __typename?: 'renewable_share_15min_aggregated_count';
+  country?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  share?: Maybe<Scalars['Int']['output']>;
+  time?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Renewable_Share_15min_Aggregated_Fields = {
+  __typename?: 'renewable_share_15min_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  share?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Renewable_Share_15min_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Renewable_Share_15min_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Renewable_Share_15min_Filter>>>;
+  country?: InputMaybe<Countries_Filter>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  share?: InputMaybe<Number_Filter_Operators>;
+  time?: InputMaybe<Date_Filter_Operators>;
+  time_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+};
+
+export type Renewable_Share_15min_Mutated = {
+  __typename?: 'renewable_share_15min_mutated';
+  data?: Maybe<Renewable_Share_15min>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Renewable_Share_Daily = {
+  __typename?: 'renewable_share_daily';
+  country?: Maybe<Countries>;
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  share?: Maybe<Scalars['Float']['output']>;
+};
+
+
+export type Renewable_Share_DailyCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Renewable_Share_Daily_Aggregated = {
+  __typename?: 'renewable_share_daily_aggregated';
+  avg?: Maybe<Renewable_Share_Daily_Aggregated_Fields>;
+  avgDistinct?: Maybe<Renewable_Share_Daily_Aggregated_Fields>;
+  count?: Maybe<Renewable_Share_Daily_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Renewable_Share_Daily_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Renewable_Share_Daily_Aggregated_Fields>;
+  min?: Maybe<Renewable_Share_Daily_Aggregated_Fields>;
+  sum?: Maybe<Renewable_Share_Daily_Aggregated_Fields>;
+  sumDistinct?: Maybe<Renewable_Share_Daily_Aggregated_Fields>;
+};
+
+export type Renewable_Share_Daily_Aggregated_Count = {
+  __typename?: 'renewable_share_daily_aggregated_count';
+  country?: Maybe<Scalars['Int']['output']>;
+  date?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  share?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Renewable_Share_Daily_Aggregated_Fields = {
+  __typename?: 'renewable_share_daily_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+  share?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Renewable_Share_Daily_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Renewable_Share_Daily_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Renewable_Share_Daily_Filter>>>;
+  country?: InputMaybe<Countries_Filter>;
+  date?: InputMaybe<Date_Filter_Operators>;
+  date_func?: InputMaybe<Date_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  share?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Renewable_Share_Daily_Mutated = {
+  __typename?: 'renewable_share_daily_mutated';
+  data?: Maybe<Renewable_Share_Daily>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Seo = {
+  __typename?: 'seo';
+  id: Scalars['ID']['output'];
+  meta_description?: Maybe<Scalars['String']['output']>;
+  og_image?: Maybe<Directus_Files>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type SeoOg_ImageArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Seo_Aggregated = {
+  __typename?: 'seo_aggregated';
+  count?: Maybe<Seo_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Seo_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Seo_Aggregated_Count = {
+  __typename?: 'seo_aggregated_count';
+  id?: Maybe<Scalars['Int']['output']>;
+  meta_description?: Maybe<Scalars['Int']['output']>;
+  og_image?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Seo_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Seo_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Seo_Filter>>>;
+  id?: InputMaybe<String_Filter_Operators>;
+  meta_description?: InputMaybe<String_Filter_Operators>;
+  og_image?: InputMaybe<Directus_Files_Filter>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Seo_Mutated = {
+  __typename?: 'seo_mutated';
+  data?: Maybe<Seo>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Sites = {
+  __typename?: 'sites';
+  domain?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Array<Maybe<Sites_Translations>>>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+
+export type SitesTranslationsArgs = {
+  filter?: InputMaybe<Sites_Translations_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Sites_Aggregated = {
+  __typename?: 'sites_aggregated';
+  count?: Maybe<Sites_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Sites_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Sites_Aggregated_Count = {
+  __typename?: 'sites_aggregated_count';
+  domain?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Sites_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Sites_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Sites_Filter>>>;
+  domain?: InputMaybe<String_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  translations?: InputMaybe<Sites_Translations_Filter>;
+  translations_func?: InputMaybe<Count_Function_Filter_Operators>;
+};
+
+export type Sites_Mutated = {
+  __typename?: 'sites_mutated';
+  data?: Maybe<Sites>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Sites_Translations = {
+  __typename?: 'sites_translations';
+  faq?: Maybe<Scalars['JSON']['output']>;
+  faq_func?: Maybe<Count_Functions>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Languages>;
+  navigation_primary?: Maybe<Scalars['JSON']['output']>;
+  navigation_primary_func?: Maybe<Count_Functions>;
+  navigation_secondary?: Maybe<Scalars['JSON']['output']>;
+  navigation_secondary_func?: Maybe<Count_Functions>;
+  popular_pages?: Maybe<Scalars['JSON']['output']>;
+  popular_pages_func?: Maybe<Count_Functions>;
+  region?: Maybe<Scalars['String']['output']>;
+  seo?: Maybe<Seo>;
+  sites_id?: Maybe<Sites>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+export type Sites_TranslationsLanguages_CodeArgs = {
+  filter?: InputMaybe<Languages_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Sites_TranslationsSeoArgs = {
+  filter?: InputMaybe<Seo_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type Sites_TranslationsSites_IdArgs = {
+  filter?: InputMaybe<Sites_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Sites_Translations_Aggregated = {
+  __typename?: 'sites_translations_aggregated';
+  avg?: Maybe<Sites_Translations_Aggregated_Fields>;
+  avgDistinct?: Maybe<Sites_Translations_Aggregated_Fields>;
+  count?: Maybe<Sites_Translations_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Sites_Translations_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Sites_Translations_Aggregated_Fields>;
+  min?: Maybe<Sites_Translations_Aggregated_Fields>;
+  sum?: Maybe<Sites_Translations_Aggregated_Fields>;
+  sumDistinct?: Maybe<Sites_Translations_Aggregated_Fields>;
+};
+
+export type Sites_Translations_Aggregated_Count = {
+  __typename?: 'sites_translations_aggregated_count';
+  faq?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  languages_code?: Maybe<Scalars['Int']['output']>;
+  navigation_primary?: Maybe<Scalars['Int']['output']>;
+  navigation_secondary?: Maybe<Scalars['Int']['output']>;
+  popular_pages?: Maybe<Scalars['Int']['output']>;
+  region?: Maybe<Scalars['Int']['output']>;
+  seo?: Maybe<Scalars['Int']['output']>;
+  sites_id?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Sites_Translations_Aggregated_Fields = {
+  __typename?: 'sites_translations_aggregated_fields';
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Sites_Translations_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Sites_Translations_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Sites_Translations_Filter>>>;
+  faq?: InputMaybe<String_Filter_Operators>;
+  faq_func?: InputMaybe<Count_Function_Filter_Operators>;
+  id?: InputMaybe<Number_Filter_Operators>;
+  languages_code?: InputMaybe<Languages_Filter>;
+  navigation_primary?: InputMaybe<String_Filter_Operators>;
+  navigation_primary_func?: InputMaybe<Count_Function_Filter_Operators>;
+  navigation_secondary?: InputMaybe<String_Filter_Operators>;
+  navigation_secondary_func?: InputMaybe<Count_Function_Filter_Operators>;
+  popular_pages?: InputMaybe<String_Filter_Operators>;
+  popular_pages_func?: InputMaybe<Count_Function_Filter_Operators>;
+  region?: InputMaybe<String_Filter_Operators>;
+  seo?: InputMaybe<Seo_Filter>;
+  sites_id?: InputMaybe<Sites_Filter>;
+  title?: InputMaybe<String_Filter_Operators>;
+};
+
+export type Sites_Translations_Mutated = {
+  __typename?: 'sites_translations_mutated';
+  data?: Maybe<Sites_Translations>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Stakeholders = {
+  __typename?: 'stakeholders';
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Directus_Files>;
+  title?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Directus_Users>;
+  user_updated?: Maybe<Directus_Users>;
+};
+
+
+export type StakeholdersImageArgs = {
+  filter?: InputMaybe<Directus_Files_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type StakeholdersUser_CreatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type StakeholdersUser_UpdatedArgs = {
+  filter?: InputMaybe<Directus_Users_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Stakeholders_Aggregated = {
+  __typename?: 'stakeholders_aggregated';
+  count?: Maybe<Stakeholders_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Stakeholders_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Stakeholders_Aggregated_Count = {
+  __typename?: 'stakeholders_aggregated_count';
+  date_created?: Maybe<Scalars['Int']['output']>;
+  date_updated?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  image?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['Int']['output']>;
+  type?: Maybe<Scalars['Int']['output']>;
+  user_created?: Maybe<Scalars['Int']['output']>;
+  user_updated?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Stakeholders_Filter = {
+  _and?: InputMaybe<Array<InputMaybe<Stakeholders_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Stakeholders_Filter>>>;
+  date_created?: InputMaybe<Date_Filter_Operators>;
+  date_created_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  date_updated?: InputMaybe<Date_Filter_Operators>;
+  date_updated_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  id?: InputMaybe<String_Filter_Operators>;
+  image?: InputMaybe<Directus_Files_Filter>;
+  title?: InputMaybe<String_Filter_Operators>;
+  type?: InputMaybe<String_Filter_Operators>;
+  user_created?: InputMaybe<Directus_Users_Filter>;
+  user_updated?: InputMaybe<Directus_Users_Filter>;
+};
+
+export type Stakeholders_Mutated = {
+  __typename?: 'stakeholders_mutated';
+  data?: Maybe<Stakeholders>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type String_Filter_Operators = {
+  _contains?: InputMaybe<Scalars['String']['input']>;
+  _empty?: InputMaybe<Scalars['Boolean']['input']>;
+  _ends_with?: InputMaybe<Scalars['String']['input']>;
+  _eq?: InputMaybe<Scalars['String']['input']>;
+  _icontains?: InputMaybe<Scalars['String']['input']>;
+  _iends_with?: InputMaybe<Scalars['String']['input']>;
+  _in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  _istarts_with?: InputMaybe<Scalars['String']['input']>;
+  _ncontains?: InputMaybe<Scalars['String']['input']>;
+  _nempty?: InputMaybe<Scalars['Boolean']['input']>;
+  _nends_with?: InputMaybe<Scalars['String']['input']>;
+  _neq?: InputMaybe<Scalars['String']['input']>;
+  _niends_with?: InputMaybe<Scalars['String']['input']>;
+  _nin?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  _nistarts_with?: InputMaybe<Scalars['String']['input']>;
+  _nnull?: InputMaybe<Scalars['Boolean']['input']>;
+  _nstarts_with?: InputMaybe<Scalars['String']['input']>;
+  _null?: InputMaybe<Scalars['Boolean']['input']>;
+  _starts_with?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Version_At_Geosphere_Data = {
+  __typename?: 'version_at_geosphere_data';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  sh?: Maybe<Scalars['Float']['output']>;
+  station?: Maybe<Scalars['JSON']['output']>;
+  tl_mittel?: Maybe<Scalars['Float']['output']>;
+  tlmax?: Maybe<Scalars['Float']['output']>;
+  tlmin?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_At_Geosphere_Stations = {
+  __typename?: 'version_at_geosphere_stations';
+  height?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  snow_coverage?: Maybe<Scalars['Float']['output']>;
+  start?: Maybe<Scalars['Date']['output']>;
+  start_func?: Maybe<Date_Functions>;
+  state?: Maybe<Scalars['String']['output']>;
+  station?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Biomasse_Produktion = {
+  __typename?: 'version_biomasse_produktion';
+  Biomasse?: Maybe<Scalars['Float']['output']>;
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Biomasse_Zielpfad = {
+  __typename?: 'version_biomasse_zielpfad';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Chart = {
+  __typename?: 'version_block_chart';
+  charts?: Maybe<Scalars['JSON']['output']>;
+  charts_func?: Maybe<Count_Functions>;
+  hidewrapper?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Chart_Charts = {
+  __typename?: 'version_block_chart_charts';
+  block?: Maybe<Scalars['JSON']['output']>;
+  chart?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Donation = {
+  __typename?: 'version_block_donation';
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Block_Donation_Translations = {
+  __typename?: 'version_block_donation_translations';
+  block_donation_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  links?: Maybe<Scalars['JSON']['output']>;
+  links_func?: Maybe<Count_Functions>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_Gallery = {
+  __typename?: 'version_block_gallery';
+  files?: Maybe<Scalars['JSON']['output']>;
+  files_func?: Maybe<Count_Functions>;
+  id: Scalars['ID']['output'];
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_Gallery_Files = {
+  __typename?: 'version_block_gallery_files';
+  block_gallery_id?: Maybe<Scalars['JSON']['output']>;
+  directus_files_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Grid = {
+  __typename?: 'version_block_grid';
+  blocks?: Maybe<Scalars['JSON']['output']>;
+  blocks_func?: Maybe<Count_Functions>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Grid_Blocks = {
+  __typename?: 'version_block_grid_blocks';
+  block_grid_id?: Maybe<Scalars['JSON']['output']>;
+  collection?: Maybe<Scalars['String']['output']>;
+  height?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  item?: Maybe<Scalars['String']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  width?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_Items = {
+  __typename?: 'version_block_items';
+  id: Scalars['ID']['output'];
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  types?: Maybe<Scalars['JSON']['output']>;
+  types_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Block_Items_Translations = {
+  __typename?: 'version_block_items_translations';
+  block_items_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_News = {
+  __typename?: 'version_block_news';
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Panel = {
+  __typename?: 'version_block_panel';
+  chart?: Maybe<Scalars['JSON']['output']>;
+  chart_custom?: Maybe<Scalars['String']['output']>;
+  colorBackground?: Maybe<Scalars['String']['output']>;
+  colorText?: Maybe<Scalars['String']['output']>;
+  icon?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  number?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  unit?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_Panel_Translations = {
+  __typename?: 'version_block_panel_translations';
+  block_panel_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  link?: Maybe<Scalars['String']['output']>;
+  list?: Maybe<Scalars['JSON']['output']>;
+  list_func?: Maybe<Count_Functions>;
+  source?: Maybe<Scalars['String']['output']>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_Quiz = {
+  __typename?: 'version_block_quiz';
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Quotes = {
+  __typename?: 'version_block_quotes';
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Block_Richtext = {
+  __typename?: 'version_block_richtext';
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Block_Richtext_Translations = {
+  __typename?: 'version_block_richtext_translations';
+  block_richtext_id?: Maybe<Scalars['JSON']['output']>;
+  content?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Block_Teaser = {
+  __typename?: 'version_block_teaser';
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['JSON']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Block_Teaser_Translations = {
+  __typename?: 'version_block_teaser_translations';
+  block_teaser_id?: Maybe<Scalars['JSON']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  eyebrow?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  link?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Block_Toggle = {
+  __typename?: 'version_block_toggle';
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Block_Toggle_Translations = {
+  __typename?: 'version_block_toggle_translations';
+  answer?: Maybe<Scalars['String']['output']>;
+  block_toggle_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  question?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Carbon_Prices = {
+  __typename?: 'version_carbon_prices';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  region?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Charts = {
+  __typename?: 'version_charts';
+  custom_sveltestring?: Maybe<Scalars['String']['output']>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  id_old?: Maybe<Scalars['String']['output']>;
+  layers?: Maybe<Scalars['JSON']['output']>;
+  layers_func?: Maybe<Count_Functions>;
+  options?: Maybe<Scalars['JSON']['output']>;
+  options_func?: Maybe<Count_Functions>;
+  site?: Maybe<Scalars['JSON']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  table_name?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  type?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+  x_axis?: Maybe<Scalars['String']['output']>;
+  x_axis_name?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Charts_Translations = {
+  __typename?: 'version_charts_translations';
+  charts_id?: Maybe<Scalars['JSON']['output']>;
+  heading?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  methods?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  variables?: Maybe<Scalars['JSON']['output']>;
+  variables_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Companies = {
+  __typename?: 'version_companies';
+  climate_neutrality_goal?: Maybe<Scalars['String']['output']>;
+  climate_neutrality_scopes?: Maybe<Scalars['JSON']['output']>;
+  climate_neutrality_scopes_func?: Maybe<Count_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  intermediate_goal?: Maybe<Scalars['Boolean']['output']>;
+  logo?: Maybe<Scalars['JSON']['output']>;
+  member_sbt?: Maybe<Scalars['Boolean']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  sectors?: Maybe<Scalars['JSON']['output']>;
+  sectors_func?: Maybe<Count_Functions>;
+  status?: Maybe<Scalars['String']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Companies_Companies_Sectors = {
+  __typename?: 'version_companies_companies_sectors';
+  companies_id?: Maybe<Scalars['JSON']['output']>;
+  companies_sectors_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Companies_Emissions = {
+  __typename?: 'version_companies_emissions';
+  category?: Maybe<Scalars['String']['output']>;
+  company?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  notes?: Maybe<Scalars['String']['output']>;
+  scope?: Maybe<Scalars['Int']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  source_link?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['GraphQLBigInt']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Companies_Sectors = {
+  __typename?: 'version_companies_sectors';
+  icon?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Countries = {
+  __typename?: 'version_countries';
+  area?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['String']['output']>;
+  longitude?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  name_de?: Maybe<Scalars['String']['output']>;
+  population?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Datasets = {
+  __typename?: 'version_datasets';
+  id: Scalars['ID']['output'];
+};
+
+export type Version_De_Dwd_Data = {
+  __typename?: 'version_de_dwd_data';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  sh?: Maybe<Scalars['Float']['output']>;
+  station?: Maybe<Scalars['JSON']['output']>;
+  tl_mittel?: Maybe<Scalars['Float']['output']>;
+  tlmax?: Maybe<Scalars['Float']['output']>;
+  tlmin?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_De_Dwd_Stations = {
+  __typename?: 'version_de_dwd_stations';
+  date_start?: Maybe<Scalars['Date']['output']>;
+  date_start_func?: Maybe<Date_Functions>;
+  height?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  snow_coverage?: Maybe<Scalars['Float']['output']>;
+  state?: Maybe<Scalars['String']['output']>;
+  station?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Ee_Goals = {
+  __typename?: 'version_ee_goals';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  current_production?: Maybe<Scalars['Float']['output']>;
+  goal_amount?: Maybe<Scalars['String']['output']>;
+  goal_year?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  last_update_check?: Maybe<Scalars['Date']['output']>;
+  last_update_check_func?: Maybe<Date_Functions>;
+  note?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['JSON']['output']>;
+  source_label?: Maybe<Scalars['String']['output']>;
+  source_link?: Maybe<Scalars['String']['output']>;
+  source_year?: Maybe<Scalars['Int']['output']>;
+  unit?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+};
+
+export type Version_Ee_Historisch = {
+  __typename?: 'version_ee_historisch';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  pv?: Maybe<Scalars['Float']['output']>;
+  region?: Maybe<Scalars['JSON']['output']>;
+  wasserkraft?: Maybe<Scalars['Float']['output']>;
+  windkraft?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Ee_Potentiale = {
+  __typename?: 'version_ee_potentiale';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  id: Scalars['ID']['output'];
+  link?: Maybe<Scalars['String']['output']>;
+  note?: Maybe<Scalars['String']['output']>;
+  potential_class?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  region?: Maybe<Scalars['JSON']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  value_TWh?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Ee_Produktion = {
+  __typename?: 'version_ee_produktion';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  id: Scalars['ID']['output'];
+  unit?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Ee_Zielpfad = {
+  __typename?: 'version_ee_zielpfad';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Type?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Emissions = {
+  __typename?: 'version_emissions';
+  category?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  update?: Maybe<Scalars['Date']['output']>;
+  update_func?: Maybe<Datetime_Functions>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Energy = {
+  __typename?: 'version_energy';
+  category?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['String']['output']>;
+  period_x?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  update?: Maybe<Scalars['Date']['output']>;
+  update_func?: Maybe<Datetime_Functions>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Energy_Renewable_Share = {
+  __typename?: 'version_energy_renewable_share';
+  category?: Maybe<Scalars['String']['output']>;
+  country?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['Date']['output']>;
+  period_func?: Maybe<Datetime_Functions>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Erneuerbare_2030_Scenarios = {
+  __typename?: 'version_erneuerbare_2030_scenarios';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  energy_type?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  release_date?: Maybe<Scalars['Date']['output']>;
+  release_date_func?: Maybe<Date_Functions>;
+  scenario?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Gas_Imports = {
+  __typename?: 'version_gas_imports';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  import_country?: Maybe<Scalars['JSON']['output']>;
+  /** alternative to "import_country". will be used if "import_country" is null. */
+  import_source?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Global_Co2_Concentration = {
+  __typename?: 'version_global_co2_concentration';
+  id: Scalars['ID']['output'];
+  mean?: Maybe<Scalars['Float']['output']>;
+  year?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Glossary = {
+  __typename?: 'version_glossary';
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  key?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Glossary_Translations = {
+  __typename?: 'version_glossary_translations';
+  glossary_id?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Languages = {
+  __typename?: 'version_languages';
+  code: Scalars['ID']['output'];
+  direction?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Mobility = {
+  __typename?: 'version_mobility';
+  category?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  note?: Maybe<Scalars['String']['output']>;
+  period?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  unit?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Mobility_Cars = {
+  __typename?: 'version_mobility_cars';
+  category?: Maybe<Scalars['String']['output']>;
+  country?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  period?: Maybe<Scalars['String']['output']>;
+  region?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_News = {
+  __typename?: 'version_news';
+  author?: Maybe<Scalars['JSON']['output']>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  sites?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  slack_message_id?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_News_Translations = {
+  __typename?: 'version_news_translations';
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  news_id?: Maybe<Scalars['JSON']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Pages = {
+  __typename?: 'version_pages';
+  blocks?: Maybe<Scalars['JSON']['output']>;
+  blocks_func?: Maybe<Count_Functions>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  site?: Maybe<Scalars['JSON']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Pages_Blocks = {
+  __typename?: 'version_pages_blocks';
+  collection?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  item?: Maybe<Scalars['String']['output']>;
+  pages_id?: Maybe<Scalars['JSON']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Pages_Translations = {
+  __typename?: 'version_pages_translations';
+  description?: Maybe<Scalars['String']['output']>;
+  heading?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  pages_id?: Maybe<Scalars['JSON']['output']>;
+  seo?: Maybe<Scalars['JSON']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Scalars['JSON']['output']>;
+  tags_func?: Maybe<Count_Functions>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Pages_Translations_Blocks = {
+  __typename?: 'version_pages_translations_blocks';
+  collection?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  item?: Maybe<Scalars['String']['output']>;
+  pages_translations_id?: Maybe<Scalars['JSON']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Version_Policies = {
+  __typename?: 'version_policies';
+  attributes?: Maybe<Scalars['JSON']['output']>;
+  attributes_func?: Maybe<Count_Functions>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  rating?: Maybe<Scalars['Int']['output']>;
+  sort?: Maybe<Scalars['Int']['output']>;
+  stakeholders?: Maybe<Scalars['JSON']['output']>;
+  stakeholders_func?: Maybe<Count_Functions>;
+  status?: Maybe<Scalars['JSON']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  updates?: Maybe<Scalars['JSON']['output']>;
+  updates_func?: Maybe<Count_Functions>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Policies_Attributes = {
+  __typename?: 'version_policies_attributes';
+  icon?: Maybe<Scalars['String']['output']>;
+  key: Scalars['ID']['output'];
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  type?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Policies_Attributes_Translations = {
+  __typename?: 'version_policies_attributes_translations';
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  policies_attributes_key?: Maybe<Scalars['JSON']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Policies_Policies_Attributes = {
+  __typename?: 'version_policies_policies_attributes';
+  id: Scalars['ID']['output'];
+  policies_attributes_key?: Maybe<Scalars['JSON']['output']>;
+  policies_id?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Policies_Stakeholders = {
+  __typename?: 'version_policies_stakeholders';
+  id: Scalars['ID']['output'];
+  policies_id?: Maybe<Scalars['JSON']['output']>;
+  stakeholders_id?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Policies_Status = {
+  __typename?: 'version_policies_status';
+  color?: Maybe<Scalars['String']['output']>;
+  colorText?: Maybe<Scalars['String']['output']>;
+  icon?: Maybe<Scalars['String']['output']>;
+  key: Scalars['ID']['output'];
+  sort?: Maybe<Scalars['Int']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Policies_Status_Translations = {
+  __typename?: 'version_policies_status_translations';
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  label?: Maybe<Scalars['String']['output']>;
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  policies_status_key?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Policies_Translations = {
+  __typename?: 'version_policies_translations';
+  citizenDemand?: Maybe<Scalars['String']['output']>;
+  content?: Maybe<Scalars['String']['output']>;
+  governmentPlan?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  policies_id?: Maybe<Scalars['JSON']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Policies_Updates = {
+  __typename?: 'version_policies_updates';
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  policy?: Maybe<Scalars['JSON']['output']>;
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Policies_Updates_Translations = {
+  __typename?: 'version_policies_updates_translations';
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  policies_updates_id?: Maybe<Scalars['JSON']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Pv_Produktion = {
+  __typename?: 'version_pv_produktion';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  PV?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  unit?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Pv_Zielpfad = {
+  __typename?: 'version_pv_zielpfad';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Quiz_Answers = {
+  __typename?: 'version_quiz_answers';
+  answer_count?: Maybe<Scalars['Int']['output']>;
+  answer_order?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  is_true?: Maybe<Scalars['Boolean']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  question_id?: Maybe<Scalars['JSON']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Quiz_Questions = {
+  __typename?: 'version_quiz_questions';
+  answers?: Maybe<Scalars['JSON']['output']>;
+  answers_func?: Maybe<Count_Functions>;
+  countries?: Maybe<Scalars['JSON']['output']>;
+  countries_func?: Maybe<Count_Functions>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  question?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  text_answer?: Maybe<Scalars['String']['output']>;
+  text_question?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Quotes = {
+  __typename?: 'version_quotes';
+  author_image?: Maybe<Scalars['JSON']['output']>;
+  author_image_copyright?: Maybe<Scalars['String']['output']>;
+  author_name?: Maybe<Scalars['String']['output']>;
+  author_role?: Maybe<Scalars['String']['output']>;
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  sort?: Maybe<Scalars['Int']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Regions = {
+  __typename?: 'version_regions';
+  area?: Maybe<Scalars['Int']['output']>;
+  attributes?: Maybe<Scalars['JSON']['output']>;
+  attributes_func?: Maybe<Count_Functions>;
+  center?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  code?: Maybe<Scalars['String']['output']>;
+  country?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  layer?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  name_short?: Maybe<Scalars['String']['output']>;
+  nuts?: Maybe<Scalars['String']['output']>;
+  outline?: Maybe<Scalars['JSON']['output']>;
+  outline_func?: Maybe<Count_Functions>;
+  outline_simple?: Maybe<Scalars['JSON']['output']>;
+  outline_simple_func?: Maybe<Count_Functions>;
+  population?: Maybe<Scalars['Int']['output']>;
+  postcodes?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+};
+
+export type Version_Renewable_Share_15min = {
+  __typename?: 'version_renewable_share_15min';
+  country?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['ID']['output'];
+  share?: Maybe<Scalars['Float']['output']>;
+  time?: Maybe<Scalars['Date']['output']>;
+  time_func?: Maybe<Datetime_Functions>;
+};
+
+export type Version_Renewable_Share_Daily = {
+  __typename?: 'version_renewable_share_daily';
+  country?: Maybe<Scalars['JSON']['output']>;
+  date?: Maybe<Scalars['Date']['output']>;
+  date_func?: Maybe<Date_Functions>;
+  id: Scalars['ID']['output'];
+  share?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Version_Seo = {
+  __typename?: 'version_seo';
+  id: Scalars['ID']['output'];
+  meta_description?: Maybe<Scalars['String']['output']>;
+  og_image?: Maybe<Scalars['JSON']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Sites = {
+  __typename?: 'version_sites';
+  domain?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  translations?: Maybe<Scalars['JSON']['output']>;
+  translations_func?: Maybe<Count_Functions>;
+};
+
+export type Version_Sites_Translations = {
+  __typename?: 'version_sites_translations';
+  faq?: Maybe<Scalars['JSON']['output']>;
+  faq_func?: Maybe<Count_Functions>;
+  id: Scalars['ID']['output'];
+  languages_code?: Maybe<Scalars['JSON']['output']>;
+  navigation_primary?: Maybe<Scalars['JSON']['output']>;
+  navigation_primary_func?: Maybe<Count_Functions>;
+  navigation_secondary?: Maybe<Scalars['JSON']['output']>;
+  navigation_secondary_func?: Maybe<Count_Functions>;
+  popular_pages?: Maybe<Scalars['JSON']['output']>;
+  popular_pages_func?: Maybe<Count_Functions>;
+  region?: Maybe<Scalars['String']['output']>;
+  seo?: Maybe<Scalars['JSON']['output']>;
+  sites_id?: Maybe<Scalars['JSON']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type Version_Stakeholders = {
+  __typename?: 'version_stakeholders';
+  date_created?: Maybe<Scalars['Date']['output']>;
+  date_created_func?: Maybe<Datetime_Functions>;
+  date_updated?: Maybe<Scalars['Date']['output']>;
+  date_updated_func?: Maybe<Datetime_Functions>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['JSON']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  user_created?: Maybe<Scalars['JSON']['output']>;
+  user_updated?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type Version_Wasserkraft_Produktion = {
+  __typename?: 'version_wasserkraft_produktion';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Wasserkraft?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Wasserkraft_Zielpfad = {
+  __typename?: 'version_wasserkraft_zielpfad';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Windkraft_Produktion = {
+  __typename?: 'version_windkraft_produktion';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Wind?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Version_Windkraft_Zielpfad = {
+  __typename?: 'version_windkraft_zielpfad';
+  Country?: Maybe<Scalars['JSON']['output']>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+export type Wasserkraft_Produktion = {
+  __typename?: 'wasserkraft_produktion';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Wasserkraft?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Wasserkraft_ProduktionCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Wasserkraft_Produktion_Aggregated = {
+  __typename?: 'wasserkraft_produktion_aggregated';
+  avg?: Maybe<Wasserkraft_Produktion_Aggregated_Fields>;
+  avgDistinct?: Maybe<Wasserkraft_Produktion_Aggregated_Fields>;
+  count?: Maybe<Wasserkraft_Produktion_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Wasserkraft_Produktion_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Wasserkraft_Produktion_Aggregated_Fields>;
+  min?: Maybe<Wasserkraft_Produktion_Aggregated_Fields>;
+  sum?: Maybe<Wasserkraft_Produktion_Aggregated_Fields>;
+  sumDistinct?: Maybe<Wasserkraft_Produktion_Aggregated_Fields>;
+};
+
+export type Wasserkraft_Produktion_Aggregated_Count = {
+  __typename?: 'wasserkraft_produktion_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  Wasserkraft?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Wasserkraft_Produktion_Aggregated_Fields = {
+  __typename?: 'wasserkraft_produktion_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Wasserkraft?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Wasserkraft_Produktion_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Date_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  Wasserkraft?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Wasserkraft_Produktion_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Wasserkraft_Produktion_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Wasserkraft_Produktion_Mutated = {
+  __typename?: 'wasserkraft_produktion_mutated';
+  data?: Maybe<Wasserkraft_Produktion>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Wasserkraft_Zielpfad = {
+  __typename?: 'wasserkraft_zielpfad';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Wasserkraft_ZielpfadCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Wasserkraft_Zielpfad_Aggregated = {
+  __typename?: 'wasserkraft_zielpfad_aggregated';
+  avg?: Maybe<Wasserkraft_Zielpfad_Aggregated_Fields>;
+  avgDistinct?: Maybe<Wasserkraft_Zielpfad_Aggregated_Fields>;
+  count?: Maybe<Wasserkraft_Zielpfad_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Wasserkraft_Zielpfad_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Wasserkraft_Zielpfad_Aggregated_Fields>;
+  min?: Maybe<Wasserkraft_Zielpfad_Aggregated_Fields>;
+  sum?: Maybe<Wasserkraft_Zielpfad_Aggregated_Fields>;
+  sumDistinct?: Maybe<Wasserkraft_Zielpfad_Aggregated_Fields>;
+};
+
+export type Wasserkraft_Zielpfad_Aggregated_Count = {
+  __typename?: 'wasserkraft_zielpfad_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Wasserkraft_Zielpfad_Aggregated_Fields = {
+  __typename?: 'wasserkraft_zielpfad_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Wasserkraft_Zielpfad_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Date_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Wasserkraft_Zielpfad_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Wasserkraft_Zielpfad_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Wasserkraft_Zielpfad_Mutated = {
+  __typename?: 'wasserkraft_zielpfad_mutated';
+  data?: Maybe<Wasserkraft_Zielpfad>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Windkraft_Produktion = {
+  __typename?: 'windkraft_produktion';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Datetime_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Wind?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Windkraft_ProduktionCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Windkraft_Produktion_Aggregated = {
+  __typename?: 'windkraft_produktion_aggregated';
+  avg?: Maybe<Windkraft_Produktion_Aggregated_Fields>;
+  avgDistinct?: Maybe<Windkraft_Produktion_Aggregated_Fields>;
+  count?: Maybe<Windkraft_Produktion_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Windkraft_Produktion_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Windkraft_Produktion_Aggregated_Fields>;
+  min?: Maybe<Windkraft_Produktion_Aggregated_Fields>;
+  sum?: Maybe<Windkraft_Produktion_Aggregated_Fields>;
+  sumDistinct?: Maybe<Windkraft_Produktion_Aggregated_Fields>;
+};
+
+export type Windkraft_Produktion_Aggregated_Count = {
+  __typename?: 'windkraft_produktion_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  Wind?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Windkraft_Produktion_Aggregated_Fields = {
+  __typename?: 'windkraft_produktion_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  Wind?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Windkraft_Produktion_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Datetime_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  Wind?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Windkraft_Produktion_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Windkraft_Produktion_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Windkraft_Produktion_Mutated = {
+  __typename?: 'windkraft_produktion_mutated';
+  data?: Maybe<Windkraft_Produktion>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};
+
+export type Windkraft_Zielpfad = {
+  __typename?: 'windkraft_zielpfad';
+  Country?: Maybe<Countries>;
+  DateTime?: Maybe<Scalars['Date']['output']>;
+  DateTime_func?: Maybe<Date_Functions>;
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+};
+
+
+export type Windkraft_ZielpfadCountryArgs = {
+  filter?: InputMaybe<Countries_Filter>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type Windkraft_Zielpfad_Aggregated = {
+  __typename?: 'windkraft_zielpfad_aggregated';
+  avg?: Maybe<Windkraft_Zielpfad_Aggregated_Fields>;
+  avgDistinct?: Maybe<Windkraft_Zielpfad_Aggregated_Fields>;
+  count?: Maybe<Windkraft_Zielpfad_Aggregated_Count>;
+  countAll?: Maybe<Scalars['Int']['output']>;
+  countDistinct?: Maybe<Windkraft_Zielpfad_Aggregated_Count>;
+  group?: Maybe<Scalars['JSON']['output']>;
+  max?: Maybe<Windkraft_Zielpfad_Aggregated_Fields>;
+  min?: Maybe<Windkraft_Zielpfad_Aggregated_Fields>;
+  sum?: Maybe<Windkraft_Zielpfad_Aggregated_Fields>;
+  sumDistinct?: Maybe<Windkraft_Zielpfad_Aggregated_Fields>;
+};
+
+export type Windkraft_Zielpfad_Aggregated_Count = {
+  __typename?: 'windkraft_zielpfad_aggregated_count';
+  Country?: Maybe<Scalars['Int']['output']>;
+  DateTime?: Maybe<Scalars['Int']['output']>;
+  Jahresproduktion?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+};
+
+export type Windkraft_Zielpfad_Aggregated_Fields = {
+  __typename?: 'windkraft_zielpfad_aggregated_fields';
+  Jahresproduktion?: Maybe<Scalars['Float']['output']>;
+  id?: Maybe<Scalars['Float']['output']>;
+};
+
+export type Windkraft_Zielpfad_Filter = {
+  Country?: InputMaybe<Countries_Filter>;
+  DateTime?: InputMaybe<Date_Filter_Operators>;
+  DateTime_func?: InputMaybe<Date_Function_Filter_Operators>;
+  Jahresproduktion?: InputMaybe<Number_Filter_Operators>;
+  _and?: InputMaybe<Array<InputMaybe<Windkraft_Zielpfad_Filter>>>;
+  _or?: InputMaybe<Array<InputMaybe<Windkraft_Zielpfad_Filter>>>;
+  id?: InputMaybe<Number_Filter_Operators>;
+};
+
+export type Windkraft_Zielpfad_Mutated = {
+  __typename?: 'windkraft_zielpfad_mutated';
+  data?: Maybe<Windkraft_Zielpfad>;
+  event?: Maybe<EventEnum>;
+  key: Scalars['ID']['output'];
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,11 +1,15 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: vitePreprocess(),
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
+		alias: {
+			'@': path.resolve('./src')
+		}
 	}
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,13 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()]
+	plugins: [tailwindcss(), sveltekit()],
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, './src')
+		}
+	}
 });


### PR DESCRIPTION
This PR is a spike to test a graphQL + codegen based setup for data fetching from Directus. The big advantage of this setup is that we get a fully typed schema from Directus, the corresponding TypeScript types, and typed data fetching actions without manually writing code.

Click on the latest commit "test apollo graphql codegen setup" to see the relevant code changes.

Technologies used:
- [Apollo Client](https://www.apollographql.com/docs/react)
- [GraphQL Codegen for Svelte](https://the-guild.dev/graphql/codegen/docs/guides/svelte)