### PR TITLE
fix(emissionsRegion): move y-axis unit label out of bar area

### DIFF
--- a/src/lib/components/charts/custom/emissionsRegion/index.svelte
+++ b/src/lib/components/charts/custom/emissionsRegion/index.svelte
@@ -635,8 +635,7 @@
 						{#each yScale.ticks() as tick, i}
 							{@const isLast = i === yScale.ticks().length - 1}
 							<g transform="translate(0, {yScale(tick)})" class="text-xs">
-								<!-- Top gridline starts after the unit label to avoid intersection -->
-								<line x1={isLast ? margin.left + 70 : margin.left} x2={width} class="stroke-current opacity-10" />
+								<line x1={margin.left} x2={width} class="stroke-current opacity-10" />
 								<text
 									x={margin.left - 4}
 									dominant-baseline="middle"
@@ -648,8 +647,10 @@
 								</text>
 								{#if isLast}
 									<text
-										x={margin.left + 2}
+										x={margin.left - 4}
+										y={-14}
 										dominant-baseline="middle"
+										text-anchor="end"
 										fill="currentColor"
 										class="opacity-70"
 									>

--- a/src/lib/components/charts/primitives/axes/AxisY.svelte
+++ b/src/lib/components/charts/primitives/axes/AxisY.svelte
@@ -52,16 +52,15 @@
 					{format(tick)}
 				</text>
 				{#if isLast && unit}
-					{@const unitText = unit}
+					{@const unitW = unit.length * 7 + 8}
 					<rect
-						x="-2"
-						{y}
-						width={unitText.length * 7 + 10}
-						height="20"
-						transform="translate(0, -10)"
+						x={-unitW}
+						y={y - 20}
+						width={unitW}
+						height="16"
 						class="fill-white dark:fill-gray-900"
 					/>
-					<text x="2" {y} dy="0.32em" class="text-xs fill-gray-500">
+					<text x="-4" y={y - 12} text-anchor="end" class="text-xs fill-gray-500">
 						{unit}
 					</text>
 				{/if}


### PR DESCRIPTION
## Summary

Two-commit fix for Y-axis unit labels overlapping chart bars (reported in Slack 2026-05-06):

**Commit 1 — emissionsRegion custom SVG axis**
- Unit label ("Mt CO₂eq" etc.) was at , inside the bar area
- Top gridline had a compensating 70px x-offset hack to avoid the label
- Fix: move label to , ,  (left margin, above top tick); remove gridline hack

**Commit 2 — AxisY primitive (affects all charts using it)**
- Unit label was at  (right side of axis, inside chart area) at the same y as the top tick
- Fix: move to , ,  (left margin, above top tick); update opaque background rect to match
- Affects productionBasedEmissions (AT: Produktionsbasierte Emissionen) and all other charts using AxisY

Screenshot showing the bug in productionBasedEmissions ("10 Mio. t" overlapping bars, circled in red): reported by Adrian Hiss in #team_development

## Test plan

- [ ] Check emissionsRegion chart (DE and AT) — unit label should appear in left margin above top tick, not over bars
- [ ] Check AT: Produktionsbasierte Emissionen — "Mio. t" should appear above top Y-axis tick in margin
- [ ] Verify on mobile width (narrow layout)
- [ ] Check dark mode — background rect should use dark background
- [ ] Spot-check other charts using AxisY primitive (historicalEmissions, co2PriceHistory, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)